### PR TITLE
Fix initiative parent refs for project scopes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ vars.CLAUDE_CODE_REVIEW_ENABLED == 'true' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -41,4 +42,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -189,7 +189,10 @@ def _build_hierarchy(items: list[dict[str, Any]]) -> dict[str, Any]:
 
     for item in items:
         level = item["level"]
-        if level == "epic":
+        if level == "initiative":
+            item["parent_ref"] = last["scope"]
+            last["initiative"] = item["title"]
+        elif level == "epic":
             item["parent_ref"] = last["initiative"]
             last["epic"] = item["title"]
         elif level == "story":

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -78,7 +78,7 @@ def parse_plan(filepath: str) -> dict[str, Any]:
     Returns:
         Dict with keys: scope, initiative, epics, stories, tasks.
         Each item has: title, description, priority, size, blocking,
-        and (for epics/stories/tasks) parent_ref.
+        and (for initiative/epics/stories/tasks) parent_ref.
 
     Raises:
         FileNotFoundError: If the file does not exist.

--- a/scripts/tests/test_ep001_skill_structure.py
+++ b/scripts/tests/test_ep001_skill_structure.py
@@ -422,6 +422,16 @@ class TestReleaseManagementScaffolding:
         )
         assert "--generate-notes" in content
 
+    def test_claude_review_workflow_requires_explicit_enable_flag(self) -> None:
+        workflow = yaml.safe_load(
+            (
+                SKILL_ROOT / ".github" / "workflows" / "claude-code-review.yml"
+            ).read_text()
+        )
+        job = workflow["jobs"]["claude-review"]
+        assert "if" in job, "Claude review workflow must be explicitly gated"
+        assert "CLAUDE_CODE_REVIEW_ENABLED" in job["if"]
+
     def test_pr_template_mentions_release_notes_expectation(self) -> None:
         content = (SKILL_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(
             encoding="utf-8"

--- a/scripts/tests/test_plan_parser.py
+++ b/scripts/tests/test_plan_parser.py
@@ -280,8 +280,7 @@ class TestParsePlanBlocking:
 class TestParsePlanParentRef:
     def test_initiative_parent_ref_is_scope(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
-        assert result["initiative"]["parent_ref"] is not None
-        assert "Project" in result["initiative"]["parent_ref"]
+        assert result["initiative"]["parent_ref"] == result["scope"]["title"]
 
     def test_epic_parent_ref_is_initiative(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))

--- a/scripts/tests/test_plan_parser.py
+++ b/scripts/tests/test_plan_parser.py
@@ -278,6 +278,11 @@ class TestParsePlanBlocking:
 
 
 class TestParsePlanParentRef:
+    def test_initiative_parent_ref_is_scope(self, tmp_plan):
+        result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
+        assert result["initiative"]["parent_ref"] is not None
+        assert "Project" in result["initiative"]["parent_ref"]
+
     def test_epic_parent_ref_is_initiative(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
         assert result["epics"][0]["parent_ref"] is not None


### PR DESCRIPTION
## Summary
- fix the hierarchy builder so initiatives inherit the current scope as their parent
- add parser regressions that prove initiatives point at the parsed scope title
- gate the Claude Code review workflow behind an explicit opt-in repository variable to avoid failing runs when the app is not installed
- align the parser contract comment with the shipped initiative `parent_ref` behavior

## Verification
- `ruff check .`
- `pytest -q`

Closes #27