### PR TITLE
Fix blocking reference parsing and numeric resolution

### DIFF
--- a/references/plan-format.md
+++ b/references/plan-format.md
@@ -19,8 +19,12 @@ Each item should include the following attributes (as bold key-value pairs or bl
 ```
 Priority: P0 | P1 | P2
 Size: XS | S | M | L | XL
-Blocking: #N, #M   (comma-separated issue references, optional)
+Blocks: #123, #160
+Blocking: #123, #160
 ```
+
+`Blocks:` and `Blocking:` are treated as aliases. In both cases, the current
+item is the blocker, and the referenced issues are the issues it blocks.
 
 ## Minimal Example
 
@@ -48,7 +52,12 @@ Size: XS
 - Story and task headers accept both the compact documented depth and the deeper nested depth used by older examples
 - Items without an explicit Priority default to `P1`
 - Items without an explicit Size default to `M`
-- Blocking references are extracted from `Blocking:` lines or `Blocks: #N` patterns
+- Blocking references are extracted from `Blocks:` and `Blocking:` lines
+- `Blocks:` / `Blocking:` means the current item blocks the referenced issue(s)
+- `#123` references are resolved against existing GitHub issue numbers in the
+  target repository
+- Text references are resolved against parsed issue titles in the current
+  manifest
 - The parser returns a dict:
   ```json
   {

--- a/references/plan-format.md
+++ b/references/plan-format.md
@@ -19,8 +19,8 @@ Each item should include the following attributes (as bold key-value pairs or bl
 ```
 Priority: P0 | P1 | P2
 Size: XS | S | M | L | XL
-Blocks: #123, #160
-Blocking: #123, #160
+Blocks: #123, #160      (optional, comma-separated issue references)
+Blocking: #123, #160    (optional alias of Blocks:, same semantics)
 ```
 
 `Blocks:` and `Blocking:` are treated as aliases. In both cases, the current

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -59,7 +59,10 @@ LEVEL_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 
 PRIORITY_RE = re.compile(r"^Priority:\s*(P[012])", re.IGNORECASE | re.MULTILINE)
 SIZE_RE = re.compile(r"^Size:\s*(XS|S|M|L|XL)\b", re.IGNORECASE | re.MULTILINE)
-BLOCKS_RE = re.compile(r"^Blocks?:\s*(.+)", re.IGNORECASE | re.MULTILINE)
+BLOCKS_RE = re.compile(
+    r"^Block(?:s|ing)?:\s*(.+)",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 # Directory containing asset templates (resolved relative to repo root)
 _ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"

--- a/scripts/set_relationships.py
+++ b/scripts/set_relationships.py
@@ -92,6 +92,7 @@ _DEPENDENCIES_SECTION_RE = re.compile(
     r"(?ms)^(?P<heading>#{2,6}\s+Dependencies\s*$)\n*(?P<section>.*?)(?=^#{2,6}\s+\S|\Z)"
 )
 _BLOCKED_BY_LINE_RE = re.compile(r"(?m)^Blocked by:\s*.*(?:\n)?")
+_ISSUE_NUMBER_REF_RE = re.compile(r"^#?(?P<number>\d+)$")
 
 
 def set_blocking_labels(manifest: dict[str, Any], repo: str) -> None:
@@ -99,22 +100,28 @@ def set_blocking_labels(manifest: dict[str, Any], repo: str) -> None:
     by_title: dict[str, dict[str, Any]] = {v["title"]: v for v in manifest.values()}
     blocked_by_number: dict[int, dict[str, Any]] = {}
     blockers_by_blocked: dict[int, list[dict[str, Any]]] = {}
+    issue_cache: dict[int, dict[str, Any] | None] = {}
     pairs: list[tuple[dict, dict]] = []
 
     for record in manifest.values():
         for blocking_ref in record.get("blocking", []):
             # record is the blocker (it declares "Blocks: <ref>"); the
             # referenced issue is the one being blocked.
-            blocked = _find_by_ref(blocking_ref, by_title)
+            blocked = _find_by_ref(blocking_ref, by_title, repo, issue_cache)
             if blocked:
                 blocker = record
                 pairs.append((blocker, blocked))
                 blocked_by_number[blocked["number"]] = blocked
                 blockers_by_blocked.setdefault(blocked["number"], []).append(blocker)
             else:
+                target = (
+                    "manifest or repo"
+                    if _parse_issue_number_ref(blocking_ref)
+                    else "manifest"
+                )
                 print(
                     (
-                        f"[WARN] Blocking ref '{blocking_ref}' not found in manifest "
+                        f"[WARN] Blocking ref '{blocking_ref}' not found in {target} "
                         f"for #{record['number']} {record['title']}"
                     ),
                     file=sys.stderr,
@@ -143,13 +150,27 @@ def set_blocking_labels(manifest: dict[str, Any], repo: str) -> None:
     print(f"[OK] set_blocking_labels: {len(pairs)} blocking pairs processed")
 
 
-def _find_by_ref(ref: str, by_title: dict[str, Any]) -> dict[str, Any] | None:
+def _find_by_ref(
+    ref: str,
+    by_title: dict[str, Any],
+    repo: str = "",
+    issue_cache: dict[int, dict[str, Any] | None] | None = None,
+) -> dict[str, Any] | None:
     """Find a manifest record by reference string.
 
-    Uses exact match first, then falls back to substring matching.
+    Uses GitHub issue-number lookup for #N refs, then exact title match,
+    then falls back to substring matching.
     Warns if multiple substring matches are found.
     """
-    ref_lower = ref.lower().strip()
+    ref_stripped = ref.strip()
+    issue_number = _parse_issue_number_ref(ref_stripped)
+    if issue_number is not None:
+        if not repo:
+            return None
+        cache = issue_cache if issue_cache is not None else {}
+        return _fetch_issue_by_number(repo, issue_number, cache)
+
+    ref_lower = ref_stripped.lower()
 
     # 1. Exact match
     for title, record in by_title.items():
@@ -176,6 +197,55 @@ def _find_by_ref(ref: str, by_title: dict[str, Any]) -> dict[str, Any] | None:
         return candidates[0][1]
 
     return None
+
+
+def _parse_issue_number_ref(ref: str) -> int | None:
+    match = _ISSUE_NUMBER_REF_RE.fullmatch(ref.strip())
+    if not match:
+        return None
+    return int(match.group("number"))
+
+
+def _fetch_issue_by_number(
+    repo: str,
+    issue_number: int,
+    issue_cache: dict[int, dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    if issue_number in issue_cache:
+        return issue_cache[issue_number]
+
+    try:
+        result = run_gh(
+            [
+                "gh",
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-H",
+                "X-GitHub-Api-Version: 2022-11-28",
+                f"/repos/{repo}/issues/{issue_number}",
+            ]
+        )
+    except GitHubAPIError as exc:
+        stderr = (exc.stderr or "").lower()
+        if "404" in stderr or "not found" in stderr:
+            issue_cache[issue_number] = None
+            return None
+        raise
+
+    payload = json.loads(result.stdout or "{}")
+    if not isinstance(payload, dict):
+        issue_cache[issue_number] = None
+        return None
+
+    record = {
+        "number": payload["number"],
+        "title": payload["title"],
+        "databaseId": payload["id"],
+        "nodeId": payload.get("node_id"),
+    }
+    issue_cache[issue_number] = record
+    return record
 
 
 def _add_label(repo: str, number: int, label: str) -> None:

--- a/scripts/set_relationships.py
+++ b/scripts/set_relationships.py
@@ -116,7 +116,7 @@ def set_blocking_labels(manifest: dict[str, Any], repo: str) -> None:
             else:
                 target = (
                     "manifest or repo"
-                    if _parse_issue_number_ref(blocking_ref)
+                    if _parse_issue_number_ref(blocking_ref) is not None
                     else "manifest"
                 )
                 print(

--- a/scripts/tests/test_ep001_skill_structure.py
+++ b/scripts/tests/test_ep001_skill_structure.py
@@ -236,6 +236,20 @@ class TestReferenceDocuments:
         content = (references_dir / "design-decisions.md").read_text(encoding="utf-8")
         assert "--body-file" in content
 
+    def test_plan_format_documents_blocks_and_blocking_aliases(
+        self, references_dir: Path
+    ) -> None:
+        content = (references_dir / "plan-format.md").read_text(encoding="utf-8")
+        assert "Blocks:" in content
+        assert "Blocking:" in content
+
+    def test_plan_format_documents_blocker_direction_and_numeric_refs(
+        self, references_dir: Path
+    ) -> None:
+        content = (references_dir / "plan-format.md").read_text(encoding="utf-8")
+        assert "#123" in content
+        assert "current item blocks" in content.lower()
+
 
 # ---------------------------------------------------------------------------
 # Story #8: agents/openai.yaml Agents Metadata

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -279,6 +279,93 @@ class TestSetBlockingLabels:
         assert body.count("| #147 | Token lease | Open |") == 1
         assert body.count("| #160 | Worker drain | Open |") == 1
 
+    def test_numeric_issue_ref_uses_github_issue_number_lookup(self):
+        manifest = {
+            "blocker-task": {
+                "number": 41,
+                "nodeId": "I_node_41",
+                "databaseId": 4100,
+                "level": "task",
+                "title": "Parser handoff",
+                "parent_ref": None,
+                "priority": "P0",
+                "size": "S",
+                "blocking": ["#182"],
+            },
+            "local-lookalike": {
+                "number": 77,
+                "nodeId": "I_node_77",
+                "databaseId": 7700,
+                "level": "story",
+                "title": "Sprint 182 planning",
+                "parent_ref": None,
+                "priority": "P1",
+                "size": "M",
+                "blocking": [],
+            },
+        }
+        updated_bodies: list[str] = []
+        relationship_posts: list[str] = []
+        labeled: dict[int, list[str]] = {}
+
+        def run_gh_side_effect(cmd, **kwargs):
+            joined = " ".join(str(part) for part in cmd)
+            if "label list" in joined:
+                return make_ok(json.dumps([{"name": "blocks"}, {"name": "blocked"}]))
+            if joined.endswith("/repos/org/repo/issues/182"):
+                return make_ok(
+                    json.dumps(
+                        {
+                            "number": 182,
+                            "title": "Queue orchestration",
+                            "id": 18200,
+                            "node_id": "I_node_182",
+                        }
+                    )
+                )
+            if "/dependencies/blocked_by" in joined and "--method" not in joined:
+                return make_ok(json.dumps({"dependencies": []}))
+            if "/dependencies/blocked_by" in joined and "--method" in joined:
+                relationship_posts.append(joined)
+            if "add-label" in joined:
+                args = list(cmd)
+                num = int(args[args.index("edit") + 1])
+                lbl = args[args.index("--add-label") + 1]
+                labeled.setdefault(num, []).append(lbl)
+            return make_ok("{}")
+
+        with (
+            patch("scripts.set_relationships.run_gh", side_effect=run_gh_side_effect),
+            patch(
+                "scripts.set_relationships.get_issue_body",
+                return_value=(
+                    "# Story: Queue orchestration\n\n"
+                    "### Dependencies\n\n"
+                    "| Ticket | Description | Status |\n"
+                    "|--------|-------------|--------|\n"
+                    "| None | No blocking dependencies | N/A |\n"
+                ),
+            ),
+            patch(
+                "scripts.set_relationships.update_issue_body",
+                side_effect=lambda repo, number, body: updated_bodies.append(body),
+            ),
+        ):
+            set_relationships.set_blocking_labels(manifest, "org/repo")
+
+        assert len(relationship_posts) == 1
+        assert (
+            "/repos/org/repo/issues/182/dependencies/blocked_by"
+            in relationship_posts[0]
+        )
+        assert "issue_id=4100" in relationship_posts[0]
+        assert "blocks" in labeled.get(41, [])
+        assert "blocked" in labeled.get(182, [])
+        assert "blocked" not in labeled.get(77, [])
+        assert len(updated_bodies) == 1
+        assert "Blocked by: #41" in updated_bodies[0]
+        assert "| #41 | Parser handoff | Open |" in updated_bodies[0]
+
     def test_idempotent_rerun_skips_existing_relationship_and_body_duplicates(self):
         updated_bodies: list[str] = []
         calls: list[str] = []
@@ -452,6 +539,35 @@ class TestSetBlockingLabels:
 
         captured = capsys.readouterr()
         assert "Blocking ref 'NonExistentTarget' not found in manifest" in captured.err
+
+    def test_numeric_issue_ref_warns_when_repo_issue_not_found(self, capsys):
+        manifest = {
+            "story-1": {
+                "number": 10,
+                "nodeId": "N10",
+                "databaseId": 1000,
+                "level": "story",
+                "title": "Blocker",
+                "parent_ref": None,
+                "priority": "P0",
+                "size": "S",
+                "blocking": ["#999"],
+            }
+        }
+
+        def run_gh_side_effect(cmd, **kwargs):
+            joined = " ".join(str(part) for part in cmd)
+            if "label list" in joined:
+                return make_ok("[]")
+            if joined.endswith("/repos/org/repo/issues/999"):
+                raise set_relationships.GitHubAPIError(cmd, 1, "404 Not Found")
+            return make_ok("{}")
+
+        with patch("scripts.set_relationships.run_gh", side_effect=run_gh_side_effect):
+            set_relationships.set_blocking_labels(manifest, "org/repo")
+
+        captured = capsys.readouterr()
+        assert "Blocking ref '#999' not found in manifest or repo" in captured.err
 
     @staticmethod
     def _run_gh_for_blocking_labels():

--- a/scripts/tests/test_plan_parser.py
+++ b/scripts/tests/test_plan_parser.py
@@ -65,6 +65,21 @@ BLOCKING_PLAN = textwrap.dedent("""\
     Size: XS
 """)
 
+BLOCKING_PREFIX_PLAN = textwrap.dedent("""\
+    # Project Scope: PS-001 Blocking Prefix Test
+    Priority: P0
+    Size: M
+
+    ## Initiative: INIT-001 Core
+    Priority: P0
+    Size: M
+
+    ### Epic: EP-001 Parser Epic
+    Priority: P0
+    Size: S
+    Blocking: #147, #160
+""")
+
 DEFAULTS_PLAN = textwrap.dedent("""\
     # Project Scope: PS-001 Defaults Test
 
@@ -260,6 +275,11 @@ class TestParsePlanBlocking:
     def test_no_blocking_gives_empty_list(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
         assert result["scope"]["blocking"] == []
+
+    def test_blocking_keyword_extracted(self, tmp_plan):
+        result = create_issues.parse_plan(str(tmp_plan(BLOCKING_PREFIX_PLAN)))
+        epic = result["epics"][0]
+        assert epic["blocking"] == ["#147", "#160"]
 
     def test_blocks_keyword_extracted(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(BLOCKING_PLAN)))


### PR DESCRIPTION
## Summary
- accept both Blocks: and Blocking: as blocker metadata aliases during plan parsing
- resolve #123 blocker references against real GitHub issue numbers instead of manifest-title substring matches
- document blocker direction and numeric ref support in plan-format.md

## Verification
- ruff check .
- pytest -q

Closes #28