### PR TITLE
feat: support multiple initiatives per scope

### DIFF
--- a/references/plan-format.md
+++ b/references/plan-format.md
@@ -1,6 +1,7 @@
 # Plan Format Reference
 
-The plan-to-project skill expects a markdown file structured with the KDTIX 5-level hierarchy.
+The plan-to-project skill expects a markdown file structured with the KDTIX
+5-level hierarchy. A single project scope may contain one or more initiatives.
 
 ## Hierarchy Levels
 
@@ -63,8 +64,12 @@ Size: XS
   {
     "scope": { "title": "...", "description": "...", "priority": "P0", "size": "M", "blocking": [] },
     "initiative": { ... },
+    "initiatives": [ { ... } ],
     "epics": [ { ... } ],
     "stories": [ { "parent_ref": "EP-001", ... } ],
     "tasks": [ { "parent_ref": "Story title", ... } ]
   }
   ```
+- `initiative` is preserved as a backward-compatible alias to the first item in
+  `initiatives`
+- Epics inherit the most recently declared initiative as their `parent_ref`

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -719,6 +719,8 @@ def create_all_issues(
     initiatives = hierarchy.get("initiatives")
     if initiatives is None:
         initiatives = [hierarchy["initiative"]] if hierarchy.get("initiative") else []
+    elif not initiatives and hierarchy.get("initiative"):
+        initiatives = [hierarchy["initiative"]]
     for initiative in initiatives:
         ordered.append(("initiative", initiative))
     for epic in hierarchy.get("epics", []):

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -716,10 +716,8 @@ def create_all_issues(
 
     if hierarchy.get("scope"):
         ordered.append(("scope", hierarchy["scope"]))
-    initiatives = hierarchy.get("initiatives")
-    if initiatives is None:
-        initiatives = [hierarchy["initiative"]] if hierarchy.get("initiative") else []
-    elif not initiatives and hierarchy.get("initiative"):
+    initiatives = hierarchy.get("initiatives") or []
+    if not initiatives and hierarchy.get("initiative"):
         initiatives = [hierarchy["initiative"]]
     for initiative in initiatives:
         ordered.append(("initiative", initiative))

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -73,15 +73,17 @@ _ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 
 
 def parse_plan(filepath: str) -> dict[str, Any]:
-    """Parse a KDTIX markdown plan into a 5-level hierarchy dict.
+    """Parse a KDTIX markdown plan into a hierarchy dict.
 
     Args:
         filepath: Path to the markdown plan file.
 
     Returns:
-        Dict with keys: scope, initiative, epics, stories, tasks.
-        Each item has: title, description, priority, size, blocking,
-        and (for initiative/epics/stories/tasks) parent_ref.
+        Dict with keys: scope, initiative, initiatives, epics, stories, tasks.
+        ``initiative`` is preserved as a backward-compatible alias to the first
+        initiative entry when present. Each item has: title, description,
+        priority, size, blocking, and (for initiative/epics/stories/tasks)
+        parent_ref.
 
     Raises:
         FileNotFoundError: If the file does not exist.
@@ -176,7 +178,8 @@ def _extract_blocking(text: str) -> list[str]:
 def _build_hierarchy(items: list[dict[str, Any]]) -> dict[str, Any]:
     """Assign parent_refs and split items into hierarchy buckets."""
     scope = next((i for i in items if i["level"] == "scope"), None)
-    initiative = next((i for i in items if i["level"] == "initiative"), None)
+    initiatives = [i for i in items if i["level"] == "initiative"]
+    initiative = initiatives[0] if initiatives else None
     epics = [i for i in items if i["level"] == "epic"]
     stories = [i for i in items if i["level"] == "story"]
     tasks = [i for i in items if i["level"] == "task"]
@@ -185,7 +188,7 @@ def _build_hierarchy(items: list[dict[str, Any]]) -> dict[str, Any]:
     # item one level above it in the flat list.
     last: dict[str, str | None] = {
         "scope": scope["title"] if scope else None,
-        "initiative": initiative["title"] if initiative else None,
+        "initiative": None,
         "epic": None,
         "story": None,
     }
@@ -207,6 +210,7 @@ def _build_hierarchy(items: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "scope": scope,
         "initiative": initiative,
+        "initiatives": initiatives,
         "epics": epics,
         "stories": stories,
         "tasks": tasks,
@@ -712,8 +716,11 @@ def create_all_issues(
 
     if hierarchy.get("scope"):
         ordered.append(("scope", hierarchy["scope"]))
-    if hierarchy.get("initiative"):
-        ordered.append(("initiative", hierarchy["initiative"]))
+    initiatives = hierarchy.get("initiatives")
+    if initiatives is None:
+        initiatives = [hierarchy["initiative"]] if hierarchy.get("initiative") else []
+    for initiative in initiatives:
+        ordered.append(("initiative", initiative))
     for epic in hierarchy.get("epics", []):
         ordered.append(("epic", epic))
     for story in hierarchy.get("stories", []):
@@ -842,7 +849,7 @@ def _cmd_parse(args: argparse.Namespace) -> None:
     hierarchy = parse_plan(args.plan)
     counts = {
         "scope": 1 if hierarchy["scope"] else 0,
-        "initiative": 1 if hierarchy["initiative"] else 0,
+        "initiatives": len(hierarchy.get("initiatives", [])),
         "epics": len(hierarchy["epics"]),
         "stories": len(hierarchy["stories"]),
         "tasks": len(hierarchy["tasks"]),

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -208,6 +208,16 @@ MINIMAL_HIERARCHY = {
         "size": "L",
         "blocking": [],
     },
+    "initiatives": [
+        {
+            "title": "Core Initiative",
+            "description": "The init.",
+            "priority": "P0",
+            "size": "L",
+            "blocking": [],
+            "parent_ref": "Test Project",
+        }
+    ],
     "epics": [
         {
             "title": "First Epic",

--- a/scripts/tests/test_create_issues.py
+++ b/scripts/tests/test_create_issues.py
@@ -464,6 +464,38 @@ class TestCreateAllIssues:
         assert all(idx < first_epic_idx for idx in initiative_indices)
 
     @patch("scripts.gh_helpers.subprocess.run")
+    def test_uses_legacy_initiative_alias_when_initiatives_list_is_empty(
+        self, mock_run, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        created_titles: list[str] = []
+        hierarchy = {**MINIMAL_HIERARCHY, "initiatives": []}
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "issue create" in joined:
+                try:
+                    idx = list(cmd).index("--title")
+                    created_titles.append(cmd[idx + 1])
+                except (ValueError, IndexError):
+                    pass
+                return make_ok("https://github.com/org/repo/issues/101")
+            if "--jq" in joined:
+                return make_ok(
+                    json.dumps({"nodeId": "N1", "databaseId": 9999, "number": 101})
+                )
+            return make_ok()
+
+        mock_run.side_effect = side_effect
+        manifest = create_issues.create_all_issues(hierarchy, {}, "org/repo")
+
+        initiative_titles = [
+            title for title in created_titles if title.startswith("Initiative:")
+        ]
+        assert initiative_titles == ["Initiative: Core Initiative"]
+        assert len(manifest) == 5
+
+    @patch("scripts.gh_helpers.subprocess.run")
     def test_manifest_json_written_to_disk(self, mock_run, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         mock_run.side_effect = self._mock_run_for_create()

--- a/scripts/tests/test_create_issues.py
+++ b/scripts/tests/test_create_issues.py
@@ -361,9 +361,10 @@ class TestCreateAllIssues:
         # scope + initiative + 1 epic + 1 story + 1 task = 5
         assert len(manifest) == 5
 
+    @patch("time.sleep")
     @patch("scripts.gh_helpers.subprocess.run")
     def test_creates_all_initiatives_in_ordered_manifest(
-        self, mock_run, tmp_path, monkeypatch
+        self, mock_run, _mock_sleep, tmp_path, monkeypatch
     ):
         monkeypatch.chdir(tmp_path)
         mock_run.side_effect = self._mock_run_for_create()
@@ -424,9 +425,10 @@ class TestCreateAllIssues:
         assert scope_idx is not None and init_idx is not None
         assert scope_idx < init_idx, "Scope must be created before Initiative"
 
+    @patch("time.sleep")
     @patch("scripts.gh_helpers.subprocess.run")
     def test_creates_both_initiatives_before_epics(
-        self, mock_run, tmp_path, monkeypatch
+        self, mock_run, _mock_sleep, tmp_path, monkeypatch
     ):
         monkeypatch.chdir(tmp_path)
         created_titles: list[str] = []
@@ -463,9 +465,10 @@ class TestCreateAllIssues:
         assert len(initiative_indices) == 2
         assert all(idx < first_epic_idx for idx in initiative_indices)
 
+    @patch("time.sleep")
     @patch("scripts.gh_helpers.subprocess.run")
     def test_uses_legacy_initiative_alias_when_initiatives_list_is_empty(
-        self, mock_run, tmp_path, monkeypatch
+        self, mock_run, _mock_sleep, tmp_path, monkeypatch
     ):
         monkeypatch.chdir(tmp_path)
         created_titles: list[str] = []

--- a/scripts/tests/test_create_issues.py
+++ b/scripts/tests/test_create_issues.py
@@ -24,6 +24,61 @@ from scripts.tests.conftest import (
     make_ok,
 )
 
+MULTI_INITIATIVE_HIERARCHY = {
+    "scope": {
+        "title": "Test Project",
+        "description": "A test.",
+        "priority": "P0",
+        "size": "L",
+        "blocking": [],
+    },
+    "initiative": {
+        "title": "Core Initiative",
+        "description": "The primary initiative.",
+        "priority": "P0",
+        "size": "L",
+        "blocking": [],
+    },
+    "initiatives": [
+        {
+            "title": "Core Initiative",
+            "description": "The primary initiative.",
+            "priority": "P0",
+            "size": "L",
+            "blocking": [],
+            "parent_ref": "Test Project",
+        },
+        {
+            "title": "Expansion Initiative",
+            "description": "The secondary initiative.",
+            "priority": "P1",
+            "size": "M",
+            "blocking": [],
+            "parent_ref": "Test Project",
+        },
+    ],
+    "epics": [
+        {
+            "title": "First Epic",
+            "description": "An epic.",
+            "priority": "P0",
+            "size": "M",
+            "blocking": [],
+            "parent_ref": "Core Initiative",
+        },
+        {
+            "title": "Second Epic",
+            "description": "Another epic.",
+            "priority": "P1",
+            "size": "M",
+            "blocking": [],
+            "parent_ref": "Expansion Initiative",
+        },
+    ],
+    "stories": [],
+    "tasks": [],
+}
+
 # ---------------------------------------------------------------------------
 # Task #18: generate_body
 # ---------------------------------------------------------------------------
@@ -307,6 +362,28 @@ class TestCreateAllIssues:
         assert len(manifest) == 5
 
     @patch("scripts.gh_helpers.subprocess.run")
+    def test_creates_all_initiatives_in_ordered_manifest(
+        self, mock_run, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        mock_run.side_effect = self._mock_run_for_create()
+
+        manifest = create_issues.create_all_issues(
+            MULTI_INITIATIVE_HIERARCHY, {}, "org/repo"
+        )
+
+        initiative_titles = [
+            record["title"]
+            for record in manifest.values()
+            if record["level"] == "initiative"
+        ]
+        assert initiative_titles == [
+            "Core Initiative",
+            "Expansion Initiative",
+        ]
+        assert len(manifest) == 5
+
+    @patch("scripts.gh_helpers.subprocess.run")
     def test_manifest_has_required_fields(self, mock_run, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         mock_run.side_effect = self._mock_run_for_create()
@@ -346,6 +423,45 @@ class TestCreateAllIssues:
         init_idx = next((i for i, lv in enumerate(levels) if "Initiative" in lv), None)
         assert scope_idx is not None and init_idx is not None
         assert scope_idx < init_idx, "Scope must be created before Initiative"
+
+    @patch("scripts.gh_helpers.subprocess.run")
+    def test_creates_both_initiatives_before_epics(
+        self, mock_run, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        created_titles: list[str] = []
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "issue create" in joined:
+                try:
+                    idx = list(cmd).index("--title")
+                    created_titles.append(cmd[idx + 1])
+                except (ValueError, IndexError):
+                    pass
+                return make_ok("https://github.com/org/repo/issues/101")
+            if "--jq" in joined:
+                return make_ok(
+                    json.dumps({"nodeId": "N1", "databaseId": 9999, "number": 101})
+                )
+            return make_ok()
+
+        mock_run.side_effect = side_effect
+        create_issues.create_all_issues(MULTI_INITIATIVE_HIERARCHY, {}, "org/repo")
+
+        first_epic_idx = next(
+            (i for i, title in enumerate(created_titles) if title.startswith("Epic:")),
+            None,
+        )
+        initiative_indices = [
+            i
+            for i, title in enumerate(created_titles)
+            if title.startswith("Initiative:")
+        ]
+
+        assert first_epic_idx is not None
+        assert len(initiative_indices) == 2
+        assert all(idx < first_epic_idx for idx in initiative_indices)
 
     @patch("scripts.gh_helpers.subprocess.run")
     def test_manifest_json_written_to_disk(self, mock_run, tmp_path, monkeypatch):
@@ -451,9 +567,7 @@ class TestGetIssueIdsRetry:
         manifest = create_issues.create_all_issues(MINIMAL_HIERARCHY, {}, "org/repo")
         assert len(manifest) == 5
         # sleep was called for the 404 retries (at least twice — once per failure)
-        retry_sleeps = [
-            c for c in mock_sleep.call_args_list if c.args[0] != 0.5
-        ]
+        retry_sleeps = [c for c in mock_sleep.call_args_list if c.args[0] != 0.5]
         assert len(retry_sleeps) >= 2
 
     @patch("time.sleep")
@@ -523,4 +637,3 @@ class TestGetIssueIdsRetry:
             return m
 
         return side_effect
-

--- a/scripts/tests/test_integration.py
+++ b/scripts/tests/test_integration.py
@@ -44,13 +44,14 @@ from scripts.tests.conftest import (
 
 
 class TestIntegrationParsePlan:
-    def test_returns_5_bucket_hierarchy(self, tmp_path):
+    def test_returns_6_bucket_hierarchy(self, tmp_path):
         plan_file = tmp_path / "plan.md"
         plan_file.write_text(SAMPLE_PLAN, encoding="utf-8")
         result = create_issues.parse_plan(str(plan_file))
         assert set(result.keys()) == {
             "scope",
             "initiative",
+            "initiatives",
             "epics",
             "stories",
             "tasks",
@@ -62,6 +63,7 @@ class TestIntegrationParsePlan:
         result = create_issues.parse_plan(str(plan_file))
         assert result["scope"] is not None
         assert result["initiative"] is not None
+        assert len(result["initiatives"]) == 1
 
     def test_correct_epic_story_task_counts(self, tmp_path):
         plan_file = tmp_path / "plan.md"
@@ -77,7 +79,7 @@ class TestIntegrationParsePlan:
         result = create_issues.parse_plan(str(plan_file))
         total = (
             (1 if result["scope"] else 0)
-            + (1 if result["initiative"] else 0)
+            + len(result["initiatives"])
             + len(result["epics"])
             + len(result["stories"])
             + len(result["tasks"])
@@ -545,7 +547,7 @@ class TestIntegrationFullPipeline:
         hierarchy = create_issues.parse_plan(str(plan_file))
         total = (
             (1 if hierarchy["scope"] else 0)
-            + (1 if hierarchy["initiative"] else 0)
+            + len(hierarchy["initiatives"])
             + len(hierarchy["epics"])
             + len(hierarchy["stories"])
             + len(hierarchy["tasks"])

--- a/scripts/tests/test_plan_parser.py
+++ b/scripts/tests/test_plan_parser.py
@@ -114,6 +114,32 @@ DOCUMENTED_LEVEL_PLAN = textwrap.dedent("""\
     Size: XS
 """)
 
+MULTI_INITIATIVE_PLAN = textwrap.dedent("""\
+    # Project Scope: PS-001 Multi Initiative
+    Priority: P0
+    Size: L
+
+    ## Initiative: INIT-001 First Initiative
+    Priority: P0
+    Size: M
+
+    ### Epic: EP-001 First Epic
+    Priority: P1
+    Size: S
+
+    ## Initiative: INIT-002 Second Initiative
+    Priority: P1
+    Size: L
+
+    ### Epic: EP-002 Second Epic
+    Priority: P2
+    Size: M
+
+    #### Story: Story under second initiative
+    Priority: P1
+    Size: S
+""")
+
 
 @pytest.fixture
 def tmp_plan(tmp_path: Path) -> callable:
@@ -133,11 +159,11 @@ def tmp_plan(tmp_path: Path) -> callable:
 
 
 class TestParsePlanStructure:
-    def test_returns_dict_with_all_five_keys(self, tmp_plan):
+    def test_returns_dict_with_all_six_keys(self, tmp_plan):
         path = tmp_plan(MINIMAL_PLAN)
         result = create_issues.parse_plan(str(path))
         assert isinstance(result, dict)
-        for key in ("scope", "initiative", "epics", "stories", "tasks"):
+        for key in ("scope", "initiative", "initiatives", "epics", "stories", "tasks"):
             assert key in result, f"parse_plan() result must have key '{key}'"
 
     def test_scope_is_single_dict(self, tmp_plan):
@@ -147,6 +173,11 @@ class TestParsePlanStructure:
     def test_initiative_is_single_dict(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
         assert isinstance(result["initiative"], dict)
+
+    def test_initiatives_is_list(self, tmp_plan):
+        result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
+        assert isinstance(result["initiatives"], list)
+        assert len(result["initiatives"]) == 1
 
     def test_epics_is_list(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
@@ -306,6 +337,17 @@ class TestParsePlanParentRef:
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
         assert result["epics"][0]["parent_ref"] is not None
 
+    def test_multiple_initiatives_preserve_first_alias_and_parent_refs(self, tmp_plan):
+        result = create_issues.parse_plan(str(tmp_plan(MULTI_INITIATIVE_PLAN)))
+
+        assert len(result["initiatives"]) == 2
+        assert result["initiative"] == result["initiatives"][0]
+        assert result["initiatives"][0]["parent_ref"] == result["scope"]["title"]
+        assert result["initiatives"][1]["parent_ref"] == result["scope"]["title"]
+        assert result["epics"][0]["parent_ref"] == result["initiatives"][0]["title"]
+        assert result["epics"][1]["parent_ref"] == result["initiatives"][1]["title"]
+        assert result["stories"][0]["parent_ref"] == result["epics"][1]["title"]
+
     def test_story_parent_ref_is_epic(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
         assert result["stories"][0]["parent_ref"] is not None
@@ -362,3 +404,15 @@ class TestParsePlanEdgeCases:
         assert result["stories"][0]["title"] == "Parse documented headings"
         assert len(result["tasks"]) == 1
         assert result["tasks"][0]["title"] == "Support documented task heading"
+
+    def test_multiple_initiatives_all_parsed(self, tmp_plan):
+        result = create_issues.parse_plan(str(tmp_plan(MULTI_INITIATIVE_PLAN)))
+
+        assert [initiative["title"] for initiative in result["initiatives"]] == [
+            "First Initiative",
+            "Second Initiative",
+        ]
+        assert [epic["title"] for epic in result["epics"]] == [
+            "First Epic",
+            "Second Epic",
+        ]


### PR DESCRIPTION
Summary:
- support multiple initiatives under a single project scope while preserving the existing initiative alias for backward compatibility
- create all initiatives in order before dependent epics and update the parser CLI counts to use the full initiatives collection
- document the updated plan contract and add regression coverage for parser, integration, and issue creation flows

Verification:
- baseline: pytest -q -> 282 passed, coverage 83.91%
- final: pytest -q -> 287 passed, coverage 83.97%
- ruff check .

Closes #26