### PR TITLE
feat: add site about page

### DIFF
--- a/scripts/tests/test_site.py
+++ b/scripts/tests/test_site.py
@@ -9,6 +9,7 @@ SITE_ROOT = ROOT / "site"
 
 def test_pages_site_files_exist() -> None:
     assert (SITE_ROOT / "index.html").exists()
+    assert (SITE_ROOT / "about.html").exists()
     assert (SITE_ROOT / "styles.css").exists()
     assert (SITE_ROOT / "app.js").exists()
     assert (SITE_ROOT / "assets" / "plugin-icon.png").exists()
@@ -22,6 +23,7 @@ def test_pages_site_content_covers_install_and_support() -> None:
     html = (SITE_ROOT / "index.html").read_text(encoding="utf-8")
 
     assert "skills.projectit.ai" in html
+    assert 'href="./about.html"' in html
     assert "plan-to-project-install --destination home-skill" in html
     assert "plan-to-project-install --destination claude-skill" in html
     assert "plan-to-project-install --destination cursor-rule" in html
@@ -48,6 +50,18 @@ def test_pages_site_content_covers_release_and_docs_links() -> None:
     assert "CHANGELOG.md" in html
     assert "RELEASING.md" in html
     assert "github.com/kdtix-open/skill-plan-to-project/releases" in html
+
+
+def test_about_page_lists_current_skill_and_usage() -> None:
+    html = (SITE_ROOT / "about.html").read_text(encoding="utf-8")
+
+    assert "About the skills catalog" in html
+    assert "Plan to Project" in html
+    assert "Convert a markdown requirements plan into a GitHub Project backlog" in html
+    assert "uvx --from git+https://github.com/kdtix-open/skill-plan-to-project" in html
+    assert "plan-to-project-install --destination home-skill" in html
+    assert "plan-to-project-install --destination claude-skill" in html
+    assert "plan-to-project-install --destination cursor-rule" in html
 
 
 def test_pages_site_script_uses_release_list_endpoint_without_404_fallback() -> None:

--- a/site/about.html
+++ b/site/about.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>skills.projectit.ai | About</title>
+    <meta
+      name="description"
+      content="Learn what lives in the skills.projectit.ai catalog, starting with the KDTIX Open plan-to-project skill and the install surfaces for Codex, Claude Code, and Cursor."
+    />
+    <link rel="icon" href="./assets/plugin-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="masthead">
+        <a class="brand" href="./index.html">
+          <img
+            src="./assets/plugin-icon.png"
+            alt="Plan to Project plugin icon"
+            class="brand-mark"
+          />
+          <span class="brand-copy">
+            <strong>KDTIX Open</strong>
+            <span>plan-to-project</span>
+          </span>
+        </a>
+        <nav class="masthead-links" aria-label="Primary">
+          <a href="./index.html">Home</a>
+          <a href="./about.html" aria-current="page">About</a>
+          <a href="./index.html#install">Install</a>
+          <a href="./index.html#workflow">Workflow</a>
+          <a href="./index.html#release-docs">Release &amp; Docs</a>
+          <a href="./index.html#support">Support</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="hero hero-about">
+          <div class="hero-copy">
+            <p class="eyebrow">About</p>
+            <h1>About the skills catalog and the workflows it publishes.</h1>
+            <p class="hero-summary">
+              <code>skills.projectit.ai</code> is the public home for KDTIX Open
+              workflow installs. Right now the catalog carries one skill:
+              <strong>Plan to Project</strong>, which turns a markdown requirements
+              plan into a GitHub Project backlog without hand-building the hierarchy
+              yourself.
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="#skills">View available skills</a>
+              <a class="button button-secondary" href="./index.html#install">
+                Go to install options
+              </a>
+            </div>
+            <ul class="signal-list" aria-label="Catalog highlights">
+              <li>Catalog is designed for Codex, Claude Code, and Cursor workflows</li>
+              <li>Each skill includes install guidance, usage patterns, and release docs</li>
+              <li>Current catalog size: 1 published skill</li>
+            </ul>
+          </div>
+
+          <aside class="hero-panel" aria-label="Catalog snapshot">
+            <p class="panel-label">Current catalog</p>
+            <div class="catalog-count">1 skill</div>
+            <p class="panel-note">
+              As more KDTIX Open workflows are published, this page will expand into a
+              broader skills index. For now, <code>plan-to-project</code> is the
+              flagship workflow.
+            </p>
+          </aside>
+        </section>
+
+        <section class="section" id="skills">
+          <div class="section-heading">
+            <p class="eyebrow">Skills</p>
+            <h2>Available skills in the catalog.</h2>
+            <p class="section-copy">
+              The catalog currently contains one production workflow. It is optimized
+              for organizations that want a repeatable path from planning documents to
+              a governed GitHub backlog.
+            </p>
+          </div>
+
+          <div class="catalog-grid">
+            <article class="skill-card">
+              <div class="skill-card-header">
+                <img
+                  src="./assets/plugin-icon.png"
+                  alt="Plan to Project icon"
+                  class="skill-card-icon"
+                />
+                <div>
+                  <p class="card-kicker">Current skill</p>
+                  <h3>Plan to Project</h3>
+                </div>
+              </div>
+              <p class="skill-card-summary">
+                Convert a markdown requirements plan into a GitHub Project backlog with
+                issue types, parent-child structure, blockers, project fields, and
+                queue ordering already wired in.
+              </p>
+              <ul class="skill-pill-list" aria-label="Plan to Project capabilities">
+                <li>Markdown plan parsing</li>
+                <li>GitHub issue creation</li>
+                <li>Project V2 field updates</li>
+                <li>Dependency and queue handling</li>
+              </ul>
+              <div class="skill-card-detail">
+                <div>
+                  <p class="card-kicker">Use it when</p>
+                  <p>
+                    You have a structured Scope → Initiative → Epic → Story → Task plan
+                    and want the backlog generated consistently instead of built by hand.
+                  </p>
+                </div>
+                <div>
+                  <p class="card-kicker">Needs</p>
+                  <p>
+                    A target GitHub org/repo, a Project V2 board, and the KDTIX markdown
+                    planning format documented in the source repository.
+                  </p>
+                </div>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section" id="how-to-use">
+          <div class="section-heading">
+            <p class="eyebrow">How to use it</p>
+            <h2>Install the skill, then invoke it in the surface your team uses.</h2>
+          </div>
+
+          <div class="usage-grid">
+            <article class="install-card">
+              <p class="card-kicker">1. Install</p>
+              <h3>Pick the agent surface</h3>
+              <p>
+                Use the installer destination that matches the environment where you
+                want the workflow to show up.
+              </p>
+              <pre><code>uvx --from git+https://github.com/kdtix-open/skill-plan-to-project \
+  plan-to-project-install --destination home-skill</code></pre>
+              <button class="copy-button" data-copy-target="home-skill">
+                Copy Codex command
+              </button>
+            </article>
+
+            <article class="install-card">
+              <p class="card-kicker">2. Choose your runtime</p>
+              <h3>Codex, Claude Code, or Cursor</h3>
+              <p>
+                The same source repo installs into multiple agent environments, so teams
+                can standardize the workflow even if contributors prefer different tools.
+              </p>
+              <pre><code>uvx --from git+https://github.com/kdtix-open/skill-plan-to-project \
+  plan-to-project-install --destination claude-skill</code></pre>
+              <button class="copy-button" data-copy-target="claude-skill">
+                Copy Claude command
+              </button>
+            </article>
+
+            <article class="install-card">
+              <p class="card-kicker">3. Run the workflow</p>
+              <h3>Point the skill at a markdown plan</h3>
+              <p>
+                Once installed, hand the agent your markdown requirements plan and ask
+                it to run <code>plan-to-project</code> against the target GitHub repo and
+                Project V2 board.
+              </p>
+              <pre><code>uvx --from git+https://github.com/kdtix-open/skill-plan-to-project \
+  plan-to-project-install --destination cursor-rule --repo-root /path/to/repo</code></pre>
+              <button class="copy-button" data-copy-target="cursor-rule">
+                Copy Cursor command
+              </button>
+            </article>
+          </div>
+
+          <article class="install-strip">
+            <div>
+              <p class="card-kicker">Prompt pattern</p>
+              <h3>Tell the agent what plan file and GitHub target to use.</h3>
+            </div>
+            <pre><code>Run plan-to-project on ./plans/project-plan.md
+against kdtix-open/my-repo and GitHub Project 8.</code></pre>
+          </article>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <p>
+          Browse the latest release information on the
+          <a href="./index.html#release-docs">homepage release section</a>
+          or inspect source and changelog on
+          <a href="https://github.com/kdtix-open/skill-plan-to-project">GitHub</a>.
+        </p>
+      </footer>
+    </div>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,7 @@
         </a>
         <nav class="masthead-links" aria-label="Primary">
           <a href="#install">Install</a>
+          <a href="./about.html">About</a>
           <a href="#workflow">Workflow</a>
           <a href="#release-docs">Release &amp; Docs</a>
           <a href="#early-access">Early Access</a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -144,12 +144,20 @@ pre {
   color: var(--foreground);
 }
 
+.masthead-links a[aria-current="page"] {
+  color: var(--foreground);
+}
+
 .hero {
   display: grid;
   grid-template-columns: 1.5fr 0.95fr;
   gap: 1.5rem;
   align-items: stretch;
   margin-bottom: 2.75rem;
+}
+
+.hero-about {
+  grid-template-columns: 1.35fr 0.65fr;
 }
 
 .hero-copy,
@@ -434,6 +442,94 @@ h3 {
   margin-top: 4.8rem;
 }
 
+.catalog-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.skill-card {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  gap: 1.2rem;
+  padding: 1.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  backdrop-filter: blur(20px);
+  box-shadow: var(--shadow);
+}
+
+.skill-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(0, 184, 212, 0.08), transparent 45%);
+  pointer-events: none;
+}
+
+.skill-card-header,
+.skill-card-detail {
+  display: grid;
+  gap: 1rem;
+}
+
+.skill-card-header {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+}
+
+.skill-card-icon {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 18px;
+  box-shadow: 0 16px 32px rgba(0, 184, 212, 0.18);
+}
+
+.skill-card-summary {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.72;
+  color: var(--foreground);
+}
+
+.skill-pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.skill-pill-list li {
+  padding: 0.72rem 0.98rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--foreground);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.catalog-count {
+  margin-bottom: 1rem;
+  font-family: "Syne", sans-serif;
+  font-size: clamp(2.2rem, 4vw, 4rem);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  color: var(--foreground);
+}
+
+.usage-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
 .release-overview {
   display: grid;
   grid-template-columns: 1.35fr 0.65fr;
@@ -640,7 +736,8 @@ h3 {
   .workflow-grid,
   .release-grid,
   .access-grid,
-  .insider-panel {
+  .insider-panel,
+  .usage-grid {
     grid-template-columns: 1fr 1fr;
   }
 
@@ -671,7 +768,8 @@ h3 {
   .workflow-grid,
   .release-grid,
   .install-grid,
-  .insider-panel {
+  .insider-panel,
+  .usage-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated About page for skills.projectit.ai
- list the current Plan to Project skill and describe what it does
- explain how to install and use the skill across Codex, Claude Code, and Cursor

## Verification
- pytest -q
- ruff check .
- local Playwright validation of /about.html
- deployed to Cloudflare Pages and verified at https://skills.projectit.ai/about