### PR TITLE
feat(compliance): P0-4 placeholder scanner + fail-ship gate (FR #34 Stage 1)

### DIFF
--- a/scripts/compliance_check.py
+++ b/scripts/compliance_check.py
@@ -47,6 +47,39 @@ WHY_MATTERS_RE = re.compile(
 TLDR_RE = re.compile(r"^#{1,4}\s+TL;?DR", re.MULTILINE | re.IGNORECASE)
 DONE_WHEN_RE = re.compile(r"I Know I Am Done When", re.IGNORECASE)
 
+# P0-4 (FR #34 Stage 1): unreplaced template placeholder scanner.
+#
+# Detects literal [PLACEHOLDER] strings that `scripts/create_issues.py`
+# _render_template() failed to replace — e.g. [CRITERION 1], [ASSUMPTION 1],
+# [ITEM 1], [DESCRIPTION], [PROJECT-SPECIFIC CRITERION], [Describe the
+# problem ...], etc.  The scanner is intentionally conservative: it matches
+# strings that look like the template's placeholder pattern (square-bracketed
+# content starting with uppercase, containing only uppercase / digits / space
+# / the punctuation characters the templates actually use) and excludes
+# legitimate markdown constructs.
+#
+# Allowlist:
+#   - [ ]  + [x]  + [X]  — task-list checkboxes (any length, handled
+#     separately by the regex's minimum-content requirement)
+#   - bare numeric references like [N]  NOT allowlisted — those are legit
+#     placeholders too ("issue #[N]") and should trigger P0-4
+#
+# The regex requires at least one uppercase letter at the start of the
+# bracket contents + at least 2 characters total, which naturally excludes
+# empty brackets + checkbox markers without requiring special cases.
+PLACEHOLDER_RE = re.compile(r"\[[A-Z][A-Z0-9 _,/\-\[\]—\.]+\]")
+
+# Additional placeholder patterns the templates use that don't match the
+# all-caps rule above (e.g. "[Describe the problem ...]", "[1-sentence
+# summary...]", "[Why this initiative exists...]").  These all start with a
+# capital then descend to lowercase — match them with a separate regex.
+PLACEHOLDER_DESCRIPTIVE_RE = re.compile(
+    r"\[(?:Describe|Why|List|Vision|Objective|Backend|1-sentence|1-3 sentences|"
+    r"DESCRIPTION|ITEM|CRITERION|ASSUMPTION|PROJECT-SPECIFIC|What|VERSION|POINTS|HOURS|"
+    r"P0/P1/P2|POINTS\] pts|HOURS\] hrs|CODE)"
+    r"[^\]]*\]"
+)
+
 
 # ---------------------------------------------------------------------------
 # Gap detection
@@ -96,6 +129,34 @@ def check_issue(
                 "rule": "P0-3",
                 "description": "Blocked issue missing Dependencies section",
                 "fixed": False,
+            }
+        )
+
+    # P0-4 (FR #34 Stage 1): Unreplaced template placeholders
+    # Detect literal [PLACEHOLDER] strings that _render_template() failed to
+    # replace.  Collect all matches + report counts.  Not auto-fixed —
+    # placeholders require the structured-parser (Stage 2) or operator input
+    # (Stage 3 interactive) to fill.  Reported as P0 to fail the ship.
+    placeholder_matches = set()
+    for m in PLACEHOLDER_RE.findall(body):
+        placeholder_matches.add(m)
+    for m in PLACEHOLDER_DESCRIPTIVE_RE.findall(body):
+        placeholder_matches.add(m)
+    if placeholder_matches:
+        # Sort for stable ordering in the gap report
+        sample = sorted(placeholder_matches)[:5]
+        total = len(placeholder_matches)
+        more_suffix = f" (+ {total - 5} more)" if total > 5 else ""
+        gaps.append(
+            {
+                "severity": "P0",
+                "rule": "P0-4",
+                "description": (
+                    f"{total} unreplaced template placeholder(s): "
+                    f"{', '.join(sample)}{more_suffix}"
+                ),
+                "fixed": False,
+                "placeholders": sorted(placeholder_matches),
             }
         )
 
@@ -210,16 +271,24 @@ def run_compliance_check(
     manifest: dict[str, Any],
     repo: str,
     output_dir: Path | None = None,
+    allow_placeholders: bool = False,
 ) -> dict[str, Any]:
     """Run compliance check on all issues in manifest.
 
     Returns a report dict with summary and per-issue gap details.
+
+    FR #34 Stage 1: P0-4 unreplaced-placeholder gaps are NOT auto-fixable
+    (they require the source plan's structured subsections or operator
+    input), so they are reported but not auto-fixed.  When any P0-4 gap is
+    present + `allow_placeholders=False`, the report includes
+    `placeholder_gate: "failed"` so callers can fail the ship (CI exit 1).
     """
     out = output_dir or Path(".")
     report: dict[str, Any] = {
         "summary": {
             "total_issues": len(manifest),
             "p0_fixed": 0,
+            "p0_placeholders": 0,  # P0-4 gaps — reported, not auto-fixed
             "p1_gaps": 0,
             "p2_gaps": 0,
         },
@@ -236,12 +305,18 @@ def run_compliance_check(
 
         gaps = check_issue(number, display_title, body, level, has_blocked)
 
-        p0_gaps = [g for g in gaps if g["severity"] == "P0"]
-        if p0_gaps:
-            fixed_body = autofix_body(body, p0_gaps)
-            update_issue_body(repo, number, fixed_body)
-            report["summary"]["p0_fixed"] += sum(1 for g in p0_gaps if g["fixed"])
+        # Separate P0-4 (placeholder) gaps from auto-fixable P0 gaps.
+        # autofix_body only knows about P0-1/P0-2/P0-3 remediations;
+        # placeholders are operator/parser work per FR #34 Stage 2+.
+        autofixable_p0 = [g for g in gaps if g["severity"] == "P0" and g["rule"] != "P0-4"]
+        placeholder_p0 = [g for g in gaps if g["rule"] == "P0-4"]
 
+        if autofixable_p0:
+            fixed_body = autofix_body(body, autofixable_p0)
+            update_issue_body(repo, number, fixed_body)
+            report["summary"]["p0_fixed"] += sum(1 for g in autofixable_p0 if g["fixed"])
+
+        report["summary"]["p0_placeholders"] += len(placeholder_p0)
         report["summary"]["p1_gaps"] += sum(1 for g in gaps if g["severity"] == "P1")
         report["summary"]["p2_gaps"] += sum(1 for g in gaps if g["severity"] == "P2")
 
@@ -254,8 +329,24 @@ def run_compliance_check(
                 }
             )
 
-        status = "✓" if not p0_gaps else f"fixed {len(p0_gaps)} P0"
+        if placeholder_p0:
+            status_extra = f", {len(placeholder_p0)} P0-4 placeholder(s)"
+        else:
+            status_extra = ""
+        status = (
+            "✓"
+            if not autofixable_p0 and not placeholder_p0
+            else f"fixed {len(autofixable_p0)} P0{status_extra}"
+        )
         print(f"[check] #{number} {display_title} — {status}")
+
+    # Gate on placeholders: if any P0-4 gap exists AND --allow-placeholders
+    # is not set, mark the report's placeholder_gate = "failed".  Caller
+    # should exit non-zero.
+    if report["summary"]["p0_placeholders"] > 0 and not allow_placeholders:
+        report["placeholder_gate"] = "failed"
+    else:
+        report["placeholder_gate"] = "passed"
 
     report_path = out / "compliance-report.json"
     report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
@@ -263,8 +354,10 @@ def run_compliance_check(
     print(
         f"[OK] compliance-report.json: "
         f"{s['p0_fixed']} P0 fixed, "
+        f"{s['p0_placeholders']} P0-4 placeholder gaps, "
         f"{s['p1_gaps']} P1 gaps, "
-        f"{s['p2_gaps']} P2 gaps"
+        f"{s['p2_gaps']} P2 gaps "
+        f"(placeholder_gate: {report['placeholder_gate']})"
     )
     return report
 
@@ -281,6 +374,18 @@ def main() -> None:
     parser.add_argument("--manifest", required=True)
     parser.add_argument("--repo", required=True)
     parser.add_argument("--output-dir", default=None, help="Output directory")
+    parser.add_argument(
+        "--allow-placeholders",
+        action="store_true",
+        help=(
+            "Allow shipping issues that contain unreplaced [PLACEHOLDER] "
+            "strings.  Use ONLY when you intentionally want to ship "
+            "incomplete issue bodies (e.g. operator will hand-fill later "
+            "via PR #34 Stage 5 'refresh' mode).  Default: fail on any P0-4 "
+            "placeholder gap so the structured-parser (Stage 2) or "
+            "interactive mode (Stage 3) must fill them first."
+        ),
+    )
     args = parser.parse_args()
 
     path = Path(args.manifest)
@@ -291,10 +396,29 @@ def main() -> None:
     manifest = json.loads(path.read_text(encoding="utf-8"))
     out = Path(args.output_dir) if args.output_dir else None
     try:
-        run_compliance_check(manifest, args.repo, output_dir=out)
+        report = run_compliance_check(
+            manifest,
+            args.repo,
+            output_dir=out,
+            allow_placeholders=args.allow_placeholders,
+        )
     except GitHubAPIError as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
         sys.exit(1)
+
+    # Exit non-zero when placeholder gate failed + not overridden.  This lets
+    # CI (or a `plan-to-project create` wrapper) fail the ship when issues
+    # still carry unreplaced [PLACEHOLDER] strings.
+    if report.get("placeholder_gate") == "failed":
+        print(
+            "[FAIL] placeholder_gate: unreplaced [PLACEHOLDER] strings "
+            "remain in issue bodies.  Run with --allow-placeholders to "
+            "override OR fill the placeholders via structured subsections "
+            "in the source plan (Stage 2) / interactive mode (Stage 3) / "
+            "refresh mode (Stage 5 — FR #34).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -742,6 +742,130 @@ class TestCheckIssue:
         assert len(p0_gaps) == 0
 
 
+class TestP0_4PlaceholderScanner:
+    """FR #34 Stage 1: detect unreplaced template [PLACEHOLDER] strings."""
+
+    def test_detects_uppercase_placeholder_criterion(self):
+        body = "## Success Criteria\n\n- [ ] [CRITERION 1]\n- [ ] [CRITERION 2]\n"
+        gaps = compliance_check.check_issue(1, "Test", body, "story")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 1
+        assert "[CRITERION 1]" in p0_4[0]["placeholders"]
+        assert "[CRITERION 2]" in p0_4[0]["placeholders"]
+
+    def test_detects_item_placeholder(self):
+        body = "## Out of Scope\n\n- [ITEM 1]\n- [ITEM 2]\n"
+        gaps = compliance_check.check_issue(1, "Test", body, "story")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 1
+        assert "[ITEM 1]" in p0_4[0]["placeholders"]
+
+    def test_detects_descriptive_placeholder(self):
+        body = (
+            "## Business Problem & Current State\n\n"
+            "[Describe the problem being solved and why the current approach is insufficient]\n"
+        )
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 1
+        placeholders = p0_4[0]["placeholders"]
+        assert any("Describe the problem" in p for p in placeholders)
+
+    def test_detects_project_specific_criterion_placeholder(self):
+        body = (
+            "## I Know I Am Done When\n\n"
+            "- [ ] [PROJECT-SPECIFIC CRITERION]\n"
+            "- [ ] TDD followed: failing test written BEFORE implementation\n"
+        )
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 1
+
+    def test_no_false_positive_on_checkbox(self):
+        body = "## Done When\n- [ ] Task 1\n- [x] Task 2\n- [X] Task 3\n"
+        gaps = compliance_check.check_issue(1, "Test", body, "story")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 0, f"False positive: {p0_4}"
+
+    def test_no_false_positive_on_clean_body(self):
+        # A body with real content + no placeholders should not trip P0-4
+        body = (
+            "## Assumptions\n"
+            "- We assume the operator has gh CLI configured\n\n"
+            "## MoSCoW Classification\n"
+            "| Priority | Item |\n"
+            "|----------|------|\n"
+            "| Must Have | Label-set creation |\n\n"
+            "## I Know I Am Done When\n\n"
+            "TDD followed: failing test written BEFORE implementation\n\n"
+            "### Security/Compliance\n- [ ] Input validated\n"
+        )
+        gaps = compliance_check.check_issue(1, "Story", body, "story")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 0, f"False positive on clean body: {p0_4}"
+
+    def test_placeholder_gap_description_includes_count(self):
+        body = (
+            "[CRITERION 1]\n[CRITERION 2]\n[ITEM 1]\n"
+            "[ASSUMPTION 1]\n[ASSUMPTION 2]\n[DESCRIPTION]\n"
+        )
+        gaps = compliance_check.check_issue(1, "Test", body, "story")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert len(p0_4) == 1
+        # 6 distinct placeholders → description should say "6 unreplaced"
+        assert "6 unreplaced" in p0_4[0]["description"]
+
+
+class TestPlaceholderGate:
+    """FR #34 Stage 1: --allow-placeholders gate for run_compliance_check."""
+
+    def test_gate_fails_when_placeholders_present_and_not_allowed(self, mocker, tmp_path):
+        # Mock the GH API calls
+        mocker.patch("scripts.compliance_check.get_issue_body", return_value="[CRITERION 1]")
+        mocker.patch("scripts.compliance_check.get_issue_labels", return_value=[])
+        mocker.patch("scripts.compliance_check.update_issue_body")
+        manifest = {
+            "Test Scope": {"number": 1, "level": "scope", "title": "Test Scope"},
+        }
+        report = compliance_check.run_compliance_check(
+            manifest, "owner/repo", output_dir=tmp_path, allow_placeholders=False
+        )
+        assert report["placeholder_gate"] == "failed"
+        assert report["summary"]["p0_placeholders"] >= 1
+
+    def test_gate_passes_when_placeholders_allowed(self, mocker, tmp_path):
+        mocker.patch("scripts.compliance_check.get_issue_body", return_value="[CRITERION 1]")
+        mocker.patch("scripts.compliance_check.get_issue_labels", return_value=[])
+        mocker.patch("scripts.compliance_check.update_issue_body")
+        manifest = {
+            "Test Scope": {"number": 1, "level": "scope", "title": "Test Scope"},
+        }
+        report = compliance_check.run_compliance_check(
+            manifest, "owner/repo", output_dir=tmp_path, allow_placeholders=True
+        )
+        assert report["placeholder_gate"] == "passed"
+
+    def test_gate_passes_when_no_placeholders_present(self, mocker, tmp_path):
+        clean_body = (
+            "## Assumptions\n- Assumption\n\n"
+            "## MoSCoW Classification\n| Must Have | X |\n\n"
+            "## I Know I Am Done When\n\n"
+            "TDD followed: failing test written BEFORE implementation\n\n"
+            "### Security/Compliance\n- [ ] OK\n"
+        )
+        mocker.patch("scripts.compliance_check.get_issue_body", return_value=clean_body)
+        mocker.patch("scripts.compliance_check.get_issue_labels", return_value=[])
+        mocker.patch("scripts.compliance_check.update_issue_body")
+        manifest = {
+            "Test Story": {"number": 1, "level": "story", "title": "Read the docs"},
+        }
+        report = compliance_check.run_compliance_check(
+            manifest, "owner/repo", output_dir=tmp_path, allow_placeholders=False
+        )
+        assert report["placeholder_gate"] == "passed"
+        assert report["summary"]["p0_placeholders"] == 0
+
+
 class TestAutofixBody:
     def test_autofix_injects_tdd_after_done_when(self):
         body = "## I Know I Am Done When\n\n- [ ] Something\n"


### PR DESCRIPTION
## Summary

First deliverable of FR #34 (placeholder-completeness). Adds a P0 compliance check that detects unreplaced template \`[PLACEHOLDER]\` strings in issue bodies + fails the ship when any are found.

Closes **Stage 1** of FR #34.  Stages 2-5 (structured parser, TBD fallback, interactive mode, refresh-existing-backlog) tracked in the same FR.

## Changes

### \`scripts/compliance_check.py\`
- New module-level regexes: \`PLACEHOLDER_RE\` (all-uppercase like \`[CRITERION 1]\`) + \`PLACEHOLDER_DESCRIPTIVE_RE\` (mixed-case like \`[Describe the problem ...]\`)
- Both naturally exclude checkbox markers (\`[ ]\` / \`[x]\` / \`[X]\`)
- New P0-4 gap rule in \`check_issue()\` — scans body, collects unique placeholders, reports with \`placeholders\` field
- \`run_compliance_check()\` separates P0-4 (not auto-fixable) from auto-fixable P0-1/P0-2/P0-3; new \`p0_placeholders\` summary field + \`placeholder_gate\` report field
- \`main()\` adds \`--allow-placeholders\` CLI flag (escape hatch); exit code 2 when gate fails

### \`scripts/tests/test_ep002_ep003_scripts.py\`
- \`TestP0_4PlaceholderScanner\` — 7 tests covering detection cases + false-positive guards (checkboxes + clean bodies)
- \`TestPlaceholderGate\` — 3 tests covering gate-fail / gate-pass-with-flag / gate-pass-clean-body

## Verification

- **\`pytest\` full suite: 299/299 passing** (was 289; +10 new)
- **Coverage: 83.96%** (above 80% threshold)
- No regressions in existing tests

## Why this matters

\`kdtix-open/agent-project-queue#182\` shipped with the template's placeholder sections still intact (3000-char custom VISION replaced correctly, but \`[CRITERION 1]\`, \`[ITEM 1]\`, \`[ASSUMPTION 1]\`, MoSCoW placeholders, etc. passed through unchanged).  Operator caught on review.  This PR makes the skill fail-ship loud + clear when any \`[PLACEHOLDER]\` remains, forcing either structured source-plan subsections (Stage 2), interactive mode (Stage 3), or explicit \`--allow-placeholders\` override (Stage 4 TBD fallback coming).

## Backwards compatibility

- Default behavior of \`compliance_check.py\` is now stricter (fails on P0-4 where it previously passed) — **this surfaces existing bugs in already-seeded projects, which is intentional**. Use \`--allow-placeholders\` to override for audit runs or while Stages 2-5 ship.
- Report schema: new keys \`p0_placeholders\` (int) + \`placeholder_gate\` (str). Existing consumers reading only legacy keys unaffected.
- Signature change: \`run_compliance_check()\` adds \`allow_placeholders=False\` kwarg with safe default.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>