### PR TITLE
fix(refresh): walker hierarchy via GraphQL (issueType on all gh versions)

### DIFF
--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -880,7 +880,9 @@ def _cmd_create(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _walk_existing_hierarchy(repo: str, scope_issue_number: int) -> list[dict[str, Any]]:
+def _walk_existing_hierarchy(
+    repo: str, scope_issue_number: int
+) -> list[dict[str, Any]]:
     """Walk sub-issue tree rooted at scope_issue_number using GH sub-issues REST.
 
     Returns a flat list of {number, title, level, parent_number} entries for
@@ -899,18 +901,53 @@ def _walk_existing_hierarchy(repo: str, scope_issue_number: int) -> list[dict[st
         return ["scope", "initiative", "epic", "story", "task"][min(depth, 4)]
 
     def _fetch_issue(number: int) -> dict[str, Any] | None:
-        # Fetch title + issue-type via `gh issue view`
+        # Fetch title + issue-type via GraphQL.
+        #
+        # We used to call `gh issue view N --json number,title,issueType` but
+        # the `issueType` field is not exposed by every installed gh CLI
+        # version (observed broken on gh 2.90.0 2026-04-16: "Unknown JSON
+        # field: issueType").  GraphQL via `gh api graphql` is stable across
+        # gh versions because the `issueType { name }` subfield is part of
+        # the public GitHub API surface, independent of whatever the gh CLI
+        # decides to whitelist for `issue view --json`.
+        if "/" not in repo:
+            return None
+        owner, name = repo.split("/", 1)
+        query = (
+            "query($owner: String!, $name: String!, $number: Int!) { "
+            "repository(owner: $owner, name: $name) { "
+            "issue(number: $number) { "
+            "number title issueType { name } "
+            "} } }"
+        )
         r = run_gh(
-            ["gh", "issue", "view", str(number), "-R", repo,
-             "--json", "number,title,issueType"],
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"owner={owner}",
+                "-f",
+                f"name={name}",
+                "-F",
+                f"number={number}",
+            ],
             check=False,
         )
         if r.returncode != 0:
             return None
         try:
-            return json.loads(r.stdout)
+            payload = json.loads(r.stdout)
         except json.JSONDecodeError:
             return None
+        issue = (payload or {}).get("data", {}).get("repository", {}).get("issue")
+        # Shape the result so callers see the same dict shape they got from
+        # the old `gh issue view --json` path: {number, title, issueType}.
+        if not issue:
+            return None
+        return issue
 
     def _fetch_sub_issues(number: int) -> list[int]:
         r = run_gh(
@@ -938,12 +975,14 @@ def _walk_existing_hierarchy(repo: str, scope_issue_number: int) -> list[dict[st
         }
         issue_type_name = (issue.get("issueType") or {}).get("name", "")
         level = level_by_type.get(issue_type_name) or _infer_level_by_depth(depth)
-        results.append({
-            "number": issue["number"],
-            "title": issue["title"],
-            "level": level,
-            "parent_number": parent_number,
-        })
+        results.append(
+            {
+                "number": issue["number"],
+                "title": issue["title"],
+                "level": level,
+                "parent_number": parent_number,
+            }
+        )
         for child_num in _fetch_sub_issues(number):
             _recurse(child_num, depth + 1, number)
 
@@ -973,7 +1012,7 @@ def _flatten_parsed_hierarchy(hierarchy: dict[str, Any]) -> dict[str, dict[str, 
             "Task:",
         ]:
             if t.lower().startswith(prefix.lower()):
-                t = t[len(prefix):].strip()
+                t = t[len(prefix) :].strip()
                 break
         return t.lower().strip()
 
@@ -1036,7 +1075,10 @@ def refresh_backlog(
         "per_issue": [],
     }
 
-    print(f"[refresh] walking existing hierarchy rooted at #{scope_issue_number} in {repo}")
+    print(
+        f"[refresh] walking existing hierarchy rooted at "
+        f"#{scope_issue_number} in {repo}"
+    )
     existing = _walk_existing_hierarchy(repo, scope_issue_number)
     report["summary"]["existing_issues"] = len(existing)
     print(f"[refresh] found {len(existing)} existing issues")
@@ -1052,11 +1094,16 @@ def refresh_backlog(
         # Normalize existing title same way
         norm = title.strip()
         for prefix in [
-            "Project Scope:", "Scope:", "Initiative:", "Epic:",
-            "Story:", "User Story:", "Task:",
+            "Project Scope:",
+            "Scope:",
+            "Initiative:",
+            "Epic:",
+            "Story:",
+            "User Story:",
+            "Task:",
         ]:
             if norm.lower().startswith(prefix.lower()):
-                norm = norm[len(prefix):].strip()
+                norm = norm[len(prefix) :].strip()
                 break
         norm = norm.lower().strip()
 
@@ -1070,7 +1117,9 @@ def refresh_backlog(
         if not item:
             per_issue_record["status"] = "unmatched"
             report["summary"]["unmatched"] += 1
-            print(f"[refresh] #{number} UNMATCHED: '{title}' (no parsed-plan counterpart)")
+            print(
+                f"[refresh] #{number} UNMATCHED: '{title}' (no parsed-plan counterpart)"
+            )
             report["per_issue"].append(per_issue_record)
             continue
 
@@ -1194,7 +1243,7 @@ def main() -> None:
         "--dry-run",
         action="store_true",
         default=True,
-        help="Preview changes without applying (DEFAULT: on).  Pass --apply to disable.",
+        help="Preview changes without applying (DEFAULT: on). Pass --apply to disable.",
     )
     p_refresh.add_argument(
         "--apply",
@@ -1202,7 +1251,9 @@ def main() -> None:
         dest="dry_run",
         help="Apply updates via `gh issue edit` (overrides --dry-run default).",
     )
-    p_refresh.add_argument("--output-dir", default=None, help="Output directory for refresh-report.json")
+    p_refresh.add_argument(
+        "--output-dir", default=None, help="Output directory for refresh-report.json"
+    )
 
     args = parser.parse_args()
     dispatch = {

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -742,11 +742,167 @@ class TestCheckIssue:
         assert len(p0_gaps) == 0
 
 
+class TestWalkExistingHierarchy:
+    """FR #34 Stage 5 walker: fetch title + issue-type via GraphQL.
+
+    Historical bug (fix/walker-graphql-issuetype): the walker used
+    `gh issue view --json issueType` which is not supported by all installed
+    gh CLI versions (e.g. gh 2.90.0 returns "Unknown JSON field: issueType").
+    The walker now issues a GraphQL query via `gh api graphql` which is
+    stable across gh versions.
+    """
+
+    @patch("scripts.gh_helpers.subprocess.run")
+    def test_fetches_issue_via_graphql_not_issue_view(self, mock_run):
+        """Walker must use `gh api graphql` so it works on all gh versions."""
+        from scripts import create_issues
+
+        # First call: GraphQL fetch of root issue #182.
+        # Second call: REST fetch of sub_issues (empty → terminates recursion).
+        mock_run.side_effect = [
+            make_ok(
+                json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "issue": {
+                                    "number": 182,
+                                    "title": "Project Scope: Test",
+                                    "issueType": {"name": "Project Scope"},
+                                }
+                            }
+                        }
+                    }
+                )
+            ),
+            make_ok("[]"),
+        ]
+        results = create_issues._walk_existing_hierarchy("owner/repo", 182)
+        assert len(results) == 1
+        assert results[0]["number"] == 182
+        assert results[0]["level"] == "scope"
+
+        # Walker must call `gh api graphql` — NOT `gh issue view --json issueType`
+        all_calls_str = str(mock_run.call_args_list)
+        assert (
+            "gh' 'api' 'graphql" in all_calls_str
+            or "gh', 'api', 'graphql" in all_calls_str
+        )
+        assert (
+            "--json" not in all_calls_str
+            or "issueType" not in all_calls_str.split("--json")[1]
+            if "--json" in all_calls_str
+            else True
+        )
+
+    @patch("scripts.gh_helpers.subprocess.run")
+    def test_walks_recursively_into_sub_issues(self, mock_run):
+        from scripts import create_issues
+
+        def side_effect(cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            # GraphQL call carries "query" text — detect by arg ordering
+            if "graphql" in cmd:
+                # Extract the number from the -F number=N arg
+                num_arg = next((a for a in cmd if a.startswith("number=")), None)
+                if not num_arg:
+                    return make_ok("{}")
+                n = int(num_arg.split("=", 1)[1])
+                titles = {
+                    182: ("Project Scope: Root", "Project Scope"),
+                    183: ("Initiative: Child A", "Initiative"),
+                    184: ("Epic: Grandchild", "Epic"),
+                }
+                title, itype = titles.get(n, (f"Issue {n}", "Task"))
+                return make_ok(
+                    json.dumps(
+                        {
+                            "data": {
+                                "repository": {
+                                    "issue": {
+                                        "number": n,
+                                        "title": title,
+                                        "issueType": {"name": itype},
+                                    }
+                                }
+                            }
+                        }
+                    )
+                )
+            if "sub_issues" in cmd_str:
+                # Map parent→children
+                if "182" in cmd_str:
+                    return make_ok(json.dumps([{"number": 183}]))
+                if "183" in cmd_str:
+                    return make_ok(json.dumps([{"number": 184}]))
+                return make_ok("[]")
+            return make_ok("{}")
+
+        mock_run.side_effect = side_effect
+
+        results = create_issues._walk_existing_hierarchy("owner/repo", 182)
+        assert [r["number"] for r in results] == [182, 183, 184]
+        assert [r["level"] for r in results] == ["scope", "initiative", "epic"]
+        assert results[1]["parent_number"] == 182
+        assert results[2]["parent_number"] == 183
+
+    @patch("scripts.gh_helpers.subprocess.run")
+    def test_fails_soft_on_graphql_error(self, mock_run):
+        """If GraphQL fails for a node, walker returns [] without crashing."""
+        from scripts import create_issues
+
+        err = make_ok("")
+        err.returncode = 1
+        err.stderr = "HTTP 502"
+        mock_run.return_value = err
+
+        results = create_issues._walk_existing_hierarchy("owner/repo", 182)
+        assert results == []
+
+    @patch("scripts.gh_helpers.subprocess.run")
+    def test_falls_back_to_depth_inference_when_issue_type_missing(self, mock_run):
+        """If issueType is null, walker falls back to depth-based level."""
+        from scripts import create_issues
+
+        mock_run.side_effect = [
+            make_ok(
+                json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "issue": {
+                                    "number": 182,
+                                    "title": "Unlabeled issue",
+                                    "issueType": None,  # no type set
+                                }
+                            }
+                        }
+                    }
+                )
+            ),
+            make_ok("[]"),
+        ]
+        results = create_issues._walk_existing_hierarchy("owner/repo", 182)
+        assert len(results) == 1
+        # depth=0 → scope by fallback
+        assert results[0]["level"] == "scope"
+
+    @patch("scripts.gh_helpers.subprocess.run")
+    def test_rejects_malformed_repo_string(self, mock_run):
+        """A repo with no '/' must not hit the network (defensive check)."""
+        from scripts import create_issues
+
+        results = create_issues._walk_existing_hierarchy("no-slash-here", 1)
+        assert results == []
+        mock_run.assert_not_called()
+
+
 class TestRefreshMode:
     """FR #34 Stage 5: refresh existing backlog in-place without duplicates."""
 
     def test_flatten_parsed_hierarchy_normalizes_prefixes(self):
         from scripts import create_issues
+
         hierarchy = {
             "scope": {"title": "Project Scope: PS-XXX Foo Bar", "description": "desc"},
             "initiatives": [{"title": "Initiative: INIT-001 Baz", "description": "x"}],
@@ -772,7 +928,12 @@ class TestRefreshMode:
         mocker.patch(
             "scripts.create_issues.parse_plan",
             return_value={
-                "scope": {"title": "Project Scope: PS-X Test", "description": "desc", "priority": "P0", "size": "M"},
+                "scope": {
+                    "title": "Project Scope: PS-X Test",
+                    "description": "desc",
+                    "priority": "P0",
+                    "size": "M",
+                },
                 "initiatives": [],
                 "epics": [],
                 "stories": [],
@@ -783,7 +944,12 @@ class TestRefreshMode:
         mocker.patch(
             "scripts.create_issues._walk_existing_hierarchy",
             return_value=[
-                {"number": 182, "title": "Project Scope: PS-X Test", "level": "scope", "parent_number": None},
+                {
+                    "number": 182,
+                    "title": "Project Scope: PS-X Test",
+                    "level": "scope",
+                    "parent_number": None,
+                },
             ],
         )
         # Mock body fetch (different from what generate_body would produce)
@@ -815,14 +981,27 @@ class TestRefreshMode:
         mocker.patch(
             "scripts.create_issues.parse_plan",
             return_value={
-                "scope": {"title": "Project Scope: PS-X Test", "description": "desc", "priority": "P0", "size": "M"},
-                "initiatives": [], "epics": [], "stories": [], "tasks": [],
+                "scope": {
+                    "title": "Project Scope: PS-X Test",
+                    "description": "desc",
+                    "priority": "P0",
+                    "size": "M",
+                },
+                "initiatives": [],
+                "epics": [],
+                "stories": [],
+                "tasks": [],
             },
         )
         mocker.patch(
             "scripts.create_issues._walk_existing_hierarchy",
             return_value=[
-                {"number": 182, "title": "Project Scope: PS-X Test", "level": "scope", "parent_number": None},
+                {
+                    "number": 182,
+                    "title": "Project Scope: PS-X Test",
+                    "level": "scope",
+                    "parent_number": None,
+                },
             ],
         )
         mocker.patch(
@@ -854,14 +1033,27 @@ class TestRefreshMode:
         mocker.patch(
             "scripts.create_issues.parse_plan",
             return_value={
-                "scope": {"title": "Project Scope: PS-X Test", "description": "d", "priority": "P0", "size": "M"},
-                "initiatives": [], "epics": [], "stories": [], "tasks": [],
+                "scope": {
+                    "title": "Project Scope: PS-X Test",
+                    "description": "d",
+                    "priority": "P0",
+                    "size": "M",
+                },
+                "initiatives": [],
+                "epics": [],
+                "stories": [],
+                "tasks": [],
             },
         )
         mocker.patch(
             "scripts.create_issues._walk_existing_hierarchy",
             return_value=[
-                {"number": 999, "title": "Some Orphan Issue Not In Plan", "level": "story", "parent_number": None},
+                {
+                    "number": 999,
+                    "title": "Some Orphan Issue Not In Plan",
+                    "level": "story",
+                    "parent_number": None,
+                },
             ],
         )
         get_body_mock = mocker.patch("scripts.gh_helpers.get_issue_body")
@@ -887,19 +1079,37 @@ class TestRefreshMode:
         mocker.patch(
             "scripts.create_issues.parse_plan",
             return_value={
-                "scope": {"title": "Project Scope: PS-X Test", "description": "d", "priority": "P0", "size": "M"},
-                "initiatives": [], "epics": [], "stories": [], "tasks": [],
+                "scope": {
+                    "title": "Project Scope: PS-X Test",
+                    "description": "d",
+                    "priority": "P0",
+                    "size": "M",
+                },
+                "initiatives": [],
+                "epics": [],
+                "stories": [],
+                "tasks": [],
             },
         )
         mocker.patch(
             "scripts.create_issues._walk_existing_hierarchy",
             return_value=[
-                {"number": 182, "title": "Project Scope: PS-X Test", "level": "scope", "parent_number": None},
+                {
+                    "number": 182,
+                    "title": "Project Scope: PS-X Test",
+                    "level": "scope",
+                    "parent_number": None,
+                },
             ],
         )
         # Generate what the skill would produce, then mock get_issue_body to return that
         expected_body = create_issues.generate_body(
-            {"title": "Project Scope: PS-X Test", "description": "d", "priority": "P0", "size": "M"},
+            {
+                "title": "Project Scope: PS-X Test",
+                "description": "d",
+                "priority": "P0",
+                "size": "M",
+            },
             "scope",
         )
         mocker.patch("scripts.gh_helpers.get_issue_body", return_value=expected_body)
@@ -938,7 +1148,8 @@ class TestP0_4PlaceholderScanner:
     def test_detects_descriptive_placeholder(self):
         body = (
             "## Business Problem & Current State\n\n"
-            "[Describe the problem being solved and why the current approach is insufficient]\n"
+            "[Describe the problem being solved and why the "
+            "current approach is insufficient]\n"
         )
         gaps = compliance_check.check_issue(1, "Test", body, "scope")
         p0_4 = [g for g in gaps if g["rule"] == "P0-4"]


### PR DESCRIPTION
## Summary

- Stage 5 walker used `gh issue view N --json number,title,issueType` — broken on gh 2.90.0 (and other versions) with `Unknown JSON field: "issueType"`.
- Swap to `gh api graphql` with a stable `issueType { name }` subquery; same return shape so callers stay identical.
- Add 5 regression tests covering graphql path, recursive walk, fail-soft on error, null-issueType fallback, malformed-repo defensive rejection.

## Symptom fixed

Before: `refresh --dry-run --scope-issue 182 --repo kdtix-open/agent-project-queue` reported:

```
[refresh] found 0 existing issues
[refresh] DONE — 0 issues | 0 matched / 0 unmatched
```

…even though #182 has sub-issue #183. Walker's `_fetch_issue` returned None for every node because the `--json issueType` flag was rejected; `_recurse` returned without appending.

After: walker returns `[{number:182,...}, {number:183,...}, ...]` correctly and refresh can do its job.

## Test plan

- [x] `python3 -m pytest` — 309 passed, 83.13% coverage
- [x] `ruff check` — All checks passed
- [ ] End-to-end: `python3 -m scripts.create_issues refresh --plan ... --repo kdtix-open/agent-project-queue --scope-issue 182 --dry-run` on a real scope after merge + reinstall

## Context

Stage 5 of FR #34 (in-place backlog upgrade) shipped in PR #36. This is the first follow-up fix for Stage 5 — the walker unit tests all mocked `_walk_existing_hierarchy` itself, so the gh-CLI compatibility gap wasn't caught. The new `TestWalkExistingHierarchy` class pins this down with a test that checks the actual subprocess command arguments.

Refs #34 Stage 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)