### PR TITLE
feat: Stage 2 structured subsection parser + renderer

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -213,6 +213,49 @@ execution order. Eligible issues: `Status=Backlog`, no `blocked` label, parent
 
 Prints ordered list to stdout and writes `queue-order.json`.
 
+### Refresh (in-place backlog upgrade) — no new / duplicate issues
+
+```bash
+python scripts/create_issues.py refresh \
+  --plan PLAN_FILE --repo REPO --scope-issue SCOPE_NUMBER --dry-run
+# Review the unified diff output, then:
+python scripts/create_issues.py refresh \
+  --plan PLAN_FILE --repo REPO --scope-issue SCOPE_NUMBER --apply
+```
+
+Patches an existing backlog that was created with an older version of the skill.
+Walks the sub-issue tree rooted at `SCOPE_NUMBER`, matches each existing issue
+to its corresponding plan item by normalized title, re-renders the body with the
+current template + structured-subsection logic, and applies `gh issue edit` when
+the body would change. Defaults to `--dry-run` — you must explicitly pass
+`--apply` to mutate GitHub. The dry-run report (`refresh-report.json`) includes
+a unified diff per would-update so you can review exactly what changes.
+
+### Structured subsection schema (FR #34 Stage 2)
+
+Plans may opt into per-item structured subsections to populate template
+placeholder groups 1:1 (otherwise they fall back to the primary narrative field
+— Vision for scope, Objective for initiative/epic, TL;DR for story, Summary for
+task). Each subsection heading can use any markdown depth (`##` through
+`######`) so long as the text (case-insensitive) matches one of:
+
+| Level | Canonical subsection | Heading aliases | Type |
+|-------|----------------------|-----------------|------|
+| scope | `business_problem` | Business Problem, Business Problem & Current State, Current State | paragraph |
+| scope | `success_criteria` | Success Criteria | bullets |
+| scope | `in_scope_capabilities` | In-Scope Capabilities, In-Scope | bullets or paragraph |
+| scope | `assumptions` | Assumptions | bullets |
+| scope | `out_of_scope` | Out of Scope | bullets |
+| scope | `moscow` | MoSCoW, MoSCoW Classification | nested bullets with `**Must Have**:`, `**Should Have**:`, `**Could Have**:`, `**Won't Have**:` sub-groups |
+| scope | `done_when` | I Know I Am Done When, Done When | bullets |
+| initiative/epic | `objective`, `release_value`, `success_criteria`, `feature_scope`, `assumptions`, `dependencies`, `done_when` | as-named | mixed |
+| epic | `code_areas`, `questions_tech_lead`, `security_compliance` | as-named | mixed |
+| story | `user_story`, `tldr`, `why_this_matters`, `moscow`, `acceptance_criteria`, `constraints`, `implementation_notes`, `security_compliance`, `subtasks_needed` | as-named | mixed |
+| task | `summary`, `context`, `done_when`, `implementation_notes`, `security_compliance` | as-named | mixed |
+
+Subsections are OPTIONAL — when absent, the original template placeholder remains
+and the P0-4 scanner flags it. This lets you adopt the schema one plan at a time.
+
 ## Design Decisions
 
 See [design-decisions.md](https://github.com/kdtix-open/skill-plan-to-project/blob/main/references/design-decisions.md) for the full

--- a/references/plan-format.md
+++ b/references/plan-format.md
@@ -73,3 +73,131 @@ Size: XS
 - `initiative` is preserved as a backward-compatible alias to the first item in
   `initiatives`
 - Epics inherit the most recently declared initiative as their `parent_ref`
+
+## Structured Subsections (FR #34 Stage 2)
+
+Each item may declare one or more subsections inside its body. The parser
+recognizes known subsection headings and maps them 1:1 to placeholder groups in
+the generated issue template. Subsection headings can use any markdown depth
+(`##` through `######`) — the depth doesn't matter, only the heading text.
+
+Subsections are OPTIONAL. When absent, the item's raw body text populates the
+primary narrative field (Vision / Objective / TL;DR / Summary) and other
+placeholders remain as template text (the P0-4 scanner flags them).
+
+### Recognized subsection names per level
+
+**Scope:**
+- `Vision`, `Project Vision` → paragraph → replaces `[VISION — ...]`
+- `Business Problem`, `Business Problem & Current State`, `Current State` → paragraph
+- `Success Criteria` → bullets → replace `- [ ] [CRITERION 1]` / `[CRITERION 2]`
+- `In-Scope Capabilities`, `In-Scope` → bullets or paragraph
+- `Assumptions` → bullets
+- `Out of Scope` → bullets
+- `MoSCoW`, `MoSCoW Classification` → nested bullets (see MoSCoW format below)
+- `I Know I Am Done When`, `Done When`, `Definition of Done` → bullets
+
+**Initiative:** `Objective`, `Release Value`, `Success Criteria`, `Feature Scope`,
+`Assumptions`, `Dependencies`, `Out of Scope`, `Artifacts`,
+`I Know I Am Done When`.
+
+**Epic:** `Objective`, `Release Value`, `Success Criteria`, `Feature Scope`,
+`Assumptions`, `Dependencies`, `I Know I Am Done When`, `Code Areas`
+(alias `Code Areas to Examine`), `Questions for Tech Lead`,
+`Security/Compliance` (aliases `Security`, `Compliance`).
+
+**Story:** `User Story`, `TL;DR` (alias `TLDR`), `Why This Matters`, `Assumptions`,
+`MoSCoW`, `Dependencies`, `I Know I Am Done When`, `Acceptance Criteria`,
+`Constraints`, `Implementation Notes`, `Security/Compliance`,
+`Subtasks Needed` (alias `Subtasks`).
+
+**Task:** `Summary`, `Context`, `I Know I Am Done When`, `Implementation Notes`,
+`Security/Compliance`.
+
+### MoSCoW format
+
+```
+#### MoSCoW
+
+**Must Have**:
+- Item A
+- Item B
+
+**Should Have**:
+- Item C
+
+**Could Have**:
+- Item D
+
+**Won't Have**:
+- Item E
+```
+
+Each `**Group**:` line starts a new bullet group. Recognized group names:
+`Must Have`, `Should Have`, `Could Have`, `Won't Have` (or `Wont Have`).
+
+### Full example
+
+```markdown
+# Project Scope: PS-001 Build Widget Platform
+
+Delivers the widget platform with full provider parity.
+
+#### Business Problem
+
+Existing widget service has no provider abstraction and cannot onboard new
+customers without a fresh rebuild.
+
+#### Success Criteria
+
+- All five providers reach feature parity
+- End-to-end test suite is green
+- Admin dashboard ships to production
+
+#### Assumptions
+
+- Target org has a GitHub Project V2 with required fields
+- Bridge has valid credentials on the host
+
+#### Out of Scope
+
+- Native Windows supervisor (deferred to Phase 2)
+
+#### MoSCoW
+
+**Must Have**:
+- Token metering
+- Admin dashboard
+
+**Should Have**:
+- Realtime alerts
+
+**Could Have**:
+- Slack integration
+
+**Won't Have**:
+- Per-user throttling (this release)
+
+#### I Know I Am Done When
+
+- All Initiatives are Done
+- Widget dashboard live in prod
+
+## Initiative: INIT-001 Widget Core
+Priority: P0
+Size: M
+
+#### Objective
+
+Ship the widget core engine that all five providers use.
+
+#### Release Value
+
+Teams can onboard a new provider in under one day instead of one week.
+```
+
+### Backward compatibility
+
+Plans without `####` subsections continue to render exactly as they did before
+— the skill falls back to using the item's raw body as the primary narrative
+field. You can adopt the subsection schema on a single plan at a time.

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -19,6 +19,7 @@ Subcommands:
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import os
 import re
@@ -105,6 +106,12 @@ def parse_plan(filepath: str) -> dict[str, Any]:
             current["priority"] = _extract_priority(body_body)
             current["size"] = _extract_size(body_body)
             current["blocking"] = _extract_blocking(body_body)
+            # Stage 2 (FR #34): extract recognized `#### Section Name`
+            # subsections from the item body so the renderer can map them
+            # 1:1 to template placeholder groups.  Safe for plans that
+            # don't use subsections (returns `{}` + the whole body as
+            # `_leading_text`).
+            current["subsections"] = _parse_subsections(body_body, current["level"])
             items.append(current)
 
     for line in lines:
@@ -172,6 +179,280 @@ def _extract_blocking(text: str) -> list[str]:
             ref = ref.strip()
             if ref:
                 result.append(ref)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 (FR #34): Structured subsection parser.
+#
+# Recognizes `#### Section Name` headings inside an item's body and maps
+# them to canonical keys so the template renderer can substitute them into
+# placeholder groups.  Unrecognized headings + free text fall into
+# `_leading_text` as a fallback for the item's primary narrative field
+# (Vision for scope, Objective for initiative/epic, TL;DR for story,
+# Summary for task).
+#
+# Subsection headings can use any markdown header depth (## through ######)
+# so long as the trimmed heading text matches one of the aliases below
+# (case-insensitive).  The outer plan parser (`parse_plan`) already filters
+# out level-prefix lines (`Project Scope:`, `Initiative:`, etc.) so
+# subsection parsing only sees the body portion of each item.
+# ---------------------------------------------------------------------------
+
+# Per-level canonical subsection keys and the heading aliases that match
+# them.  Aliases are compared case-insensitively + whitespace-normalized.
+SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
+    "scope": {
+        "vision": ["vision", "project vision"],
+        "business_problem": [
+            "business problem",
+            "business problem & current state",
+            "business problem and current state",
+            "current state",
+        ],
+        "success_criteria": ["success criteria"],
+        "in_scope_capabilities": [
+            "in-scope capabilities",
+            "in scope capabilities",
+            "in-scope",
+            "in scope",
+        ],
+        "assumptions": ["assumptions"],
+        "out_of_scope": ["out of scope", "out-of-scope"],
+        "moscow": ["moscow", "moscow classification"],
+        "done_when": [
+            "i know i am done when",
+            "done when",
+            "definition of done",
+        ],
+    },
+    "initiative": {
+        "objective": ["objective"],
+        "release_value": ["release value"],
+        "success_criteria": ["success criteria"],
+        "feature_scope": ["feature scope"],
+        "assumptions": ["assumptions"],
+        "dependencies": ["dependencies"],
+        "out_of_scope": ["out of scope", "out-of-scope"],
+        "artifacts": ["artifacts"],
+        "done_when": [
+            "i know i am done when",
+            "done when",
+            "definition of done",
+        ],
+    },
+    "epic": {
+        "objective": ["objective"],
+        "release_value": ["release value"],
+        "success_criteria": ["success criteria"],
+        "feature_scope": ["feature scope"],
+        "assumptions": ["assumptions"],
+        "dependencies": ["dependencies"],
+        "done_when": [
+            "i know i am done when",
+            "done when",
+            "definition of done",
+        ],
+        "code_areas": ["code areas", "code areas to examine"],
+        "questions_tech_lead": ["questions for tech lead"],
+        "security_compliance": [
+            "security/compliance",
+            "security",
+            "compliance",
+        ],
+    },
+    "story": {
+        "user_story": ["user story"],
+        "tldr": ["tl;dr", "tldr"],
+        "why_this_matters": ["why this matters"],
+        "assumptions": ["assumptions"],
+        "moscow": ["moscow", "moscow classification"],
+        "dependencies": ["dependencies"],
+        "done_when": [
+            "i know i am done when",
+            "done when",
+            "definition of done",
+        ],
+        "acceptance_criteria": ["acceptance criteria"],
+        "constraints": ["constraints"],
+        "implementation_notes": ["implementation notes"],
+        "security_compliance": [
+            "security/compliance",
+            "security",
+            "compliance",
+        ],
+        "subtasks_needed": ["subtasks needed", "subtasks"],
+    },
+    "task": {
+        "summary": ["summary"],
+        "context": ["context"],
+        "done_when": [
+            "i know i am done when",
+            "done when",
+            "definition of done",
+        ],
+        "implementation_notes": ["implementation notes"],
+        "security_compliance": [
+            "security/compliance",
+            "security",
+            "compliance",
+        ],
+    },
+}
+
+# Subsections parsed as a flat list of bullets (vs. free-form paragraphs).
+_BULLET_SUBSECTIONS = {
+    "success_criteria",
+    "assumptions",
+    "out_of_scope",
+    "done_when",
+    "context",
+    "constraints",
+    "artifacts",
+    "questions_tech_lead",
+}
+
+# Subsections parsed as a dict of nested bullet groups (e.g. MoSCoW's
+# Must/Should/Could/Won't Have groups).  Values are sets of group name
+# aliases.
+_NESTED_BULLET_SUBSECTIONS: dict[str, list[str]] = {
+    "moscow": [
+        "must have",
+        "should have",
+        "could have",
+        "won't have",
+        "wont have",
+    ],
+}
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(?:\[[ xX]\]\s*)?(.+?)\s*$")
+_NESTED_GROUP_RE = re.compile(r"^\*\*([^*]+)\*\*\s*:?\s*$")
+
+
+def _parse_subsections(body: str, level: str) -> dict[str, Any]:
+    """Extract recognized subsection content from an item's body.
+
+    Returns a dict keyed by canonical subsection name with shape:
+    - str (paragraph) for most keys
+    - list[str] (bullet items) for keys in `_BULLET_SUBSECTIONS`
+    - dict[str, list[str]] (nested bullets) for keys in
+      `_NESTED_BULLET_SUBSECTIONS` (e.g. MoSCoW -> {must_have: [...],
+      should_have: [...], ...})
+
+    Additionally, non-subsection text before the first recognized heading
+    is stored under `_leading_text` as a fallback for the item's primary
+    narrative field (e.g. Vision for scope, Objective for initiative).
+
+    Safe for plans that don't use subsections: returns `{}` (with
+    `_leading_text` populated if there's any body text).
+    """
+    aliases = SUBSECTION_HEADINGS.get(level, {})
+    alias_map: dict[str, str] = {}
+    for key, names in aliases.items():
+        for alias in names:
+            alias_map[alias.lower()] = key
+
+    result: dict[str, Any] = {}
+    leading: list[str] = []
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    def _flush_current() -> None:
+        nonlocal current_key, current_lines
+        if current_key is not None:
+            result[current_key] = _normalize_subsection(current_key, current_lines)
+        current_key = None
+        current_lines = []
+
+    for line in body.splitlines():
+        m = _HEADING_RE.match(line)
+        if m:
+            heading_text = m.group(2).strip()
+            heading_key = alias_map.get(heading_text.lower())
+            if heading_key is not None:
+                _flush_current()
+                current_key = heading_key
+                continue
+            # Unknown heading (e.g. `### Approach` inside Implementation
+            # Notes): keep as content rather than starting a new section.
+            if current_key is None:
+                leading.append(line)
+            else:
+                current_lines.append(line)
+            continue
+        if current_key is None:
+            leading.append(line)
+        else:
+            current_lines.append(line)
+    _flush_current()
+
+    leading_text = "\n".join(leading).strip()
+    if leading_text:
+        result["_leading_text"] = leading_text
+    return result
+
+
+def _normalize_subsection(key: str, lines: list[str]) -> Any:
+    """Shape subsection content per key's expected type."""
+    text = "\n".join(lines).strip()
+    if not text:
+        return "" if key not in _BULLET_SUBSECTIONS else []
+
+    if key in _NESTED_BULLET_SUBSECTIONS:
+        return _parse_nested_bullets(text, _NESTED_BULLET_SUBSECTIONS[key])
+
+    if key in _BULLET_SUBSECTIONS:
+        return _parse_bullets(text)
+
+    # Default: paragraph (preserves original formatting + any inline markdown)
+    return text
+
+
+def _parse_bullets(text: str) -> list[str]:
+    """Extract a flat list of bullet items from markdown text."""
+    bullets: list[str] = []
+    for line in text.splitlines():
+        m = _BULLET_RE.match(line)
+        if m:
+            content = m.group(1).strip()
+            if content:
+                bullets.append(content)
+    if not bullets and text.strip():
+        # Paragraph in a bullet-expected section: wrap as single bullet.
+        bullets = [text.strip().replace("\n", " ")]
+    return bullets
+
+
+def _parse_nested_bullets(text: str, group_names: list[str]) -> dict[str, list[str]]:
+    """Parse MoSCoW-style nested bullets with `**Group**:` sub-headers."""
+    result: dict[str, list[str]] = {}
+    current_group: str | None = None
+    current_bullets: list[str] = []
+
+    def _group_key(name: str) -> str:
+        return name.lower().replace("won't", "wont").replace(" ", "_")
+
+    group_keys = {g: _group_key(g) for g in group_names}
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        m = _NESTED_GROUP_RE.match(stripped)
+        if m:
+            heading_lower = m.group(1).strip().lower()
+            if heading_lower in group_names:
+                if current_group is not None:
+                    result[current_group] = current_bullets
+                current_group = group_keys[heading_lower]
+                current_bullets = []
+                continue
+        bullet_m = _BULLET_RE.match(line)
+        if bullet_m and current_group is not None:
+            content = bullet_m.group(1).strip()
+            if content:
+                current_bullets.append(content)
+    if current_group is not None:
+        result[current_group] = current_bullets
     return result
 
 
@@ -401,6 +682,13 @@ def generate_body(
     """Generate a template-compliant issue body for the given item and level."""
     template_text = _load_template(level)
 
+    # Stage 2 (FR #34): ensure structured subsections are parsed before
+    # rendering.  `parse_plan` populates this on every item, but callers
+    # that build their own item dict (e.g. tests, ad hoc scripts) can
+    # skip it — re-parse here as a safety net.
+    if "subsections" not in item:
+        item["subsections"] = _parse_subsections(item.get("description", ""), level)
+
     if template_text:
         body = _render_template(template_text, item, level)
     else:
@@ -433,16 +721,47 @@ def generate_body(
 
 
 def _render_template(template_text: str, item: dict[str, Any], level: str) -> str:
-    """Render an asset template by substituting placeholders."""
+    """Render an asset template by substituting metadata + subsections.
+
+    Two-phase render:
+     1. Flat metadata replacements (title, priority, size, parent ref).
+     2. Per-level subsection fillers that map plan `#### Section` content
+        into the template's placeholder groups (Stage 2 of FR #34).
+
+    Plans without structured subsections retain the previous behavior:
+    the raw description is used as the primary narrative field (Vision
+    for scope, Objective for initiative/epic, TL;DR for story, Summary
+    for task) and other placeholders remain as template text — the
+    Stage 1 P0-4 scanner catches any leaked placeholders before ship.
+    """
     title = item.get("title", "")
     desc = item.get("description", "")
     priority = item.get("priority", "P1")
     size = item.get("size", "M")
     parent = item.get("parent_ref", "")
-    vision_text = desc or "[Vision statement]"
-    obj_text = desc or "[Objective]"
-    summary_text = desc or "[1-sentence summary]"
-    impl_text = desc or "[What this task implements]"
+    subs: dict[str, Any] = item.get("subsections") or {}
+
+    # ----- phase 1: flat metadata replacements -----
+    # The primary narrative field falls back to the leading text from
+    # subsection parsing (content above the first `#### Section`), then
+    # to the whole description for plans that don't use subsections.
+    leading = subs.get("_leading_text", "") or desc
+    vision_text = (
+        subs.get("vision") or leading if level == "scope" else "[Vision statement]"
+    )
+    obj_text = (
+        subs.get("objective") or leading
+        if level in ("initiative", "epic")
+        else "[Objective]"
+    )
+    summary_text = (
+        subs.get("tldr") or leading if level == "story" else "[1-sentence summary]"
+    )
+    impl_text = (
+        subs.get("summary") or leading
+        if level == "task"
+        else "[What this task implements]"
+    )
 
     replacements = {
         "[CODE] [TITLE]": title,
@@ -456,14 +775,14 @@ def _render_template(template_text: str, item: dict[str, Any], level: str) -> st
         "[TIMEFRAME]": "TBD",
         "[OWNER]": "TBD",
         (
-            "[VISION — 1-2 sentences on the end" " state and the value delivered]"
+            "[VISION — 1-2 sentences on the end state and the value delivered]"
         ): vision_text,
         (
-            "[Why this initiative exists and what" " problem it solves — 2-4 sentences]"
+            "[Why this initiative exists and what problem it solves — 2-4 sentences]"
         ): obj_text,
         "[Why this epic exists — 2-4 sentences]": obj_text,
-        ("[1-sentence summary of what" " this story delivers]"): summary_text,
-        ("[1-3 sentences describing exactly" " what this task implements]"): impl_text,
+        "[1-sentence summary of what this story delivers]": summary_text,
+        "[1-3 sentences describing exactly what this task implements]": impl_text,
         "[VERSION]": "TBD",
         "[POINTS]": "TBD",
         "[HOURS]": "TBD",
@@ -472,16 +791,32 @@ def _render_template(template_text: str, item: dict[str, Any], level: str) -> st
         "#[N] [EPIC TITLE]": parent or "TBD",
         "#[N] [STORY TITLE]": parent or "TBD",
         "[Backend/Frontend/Infrastructure/QA]": "Backend",
+        # Stage 2: placeholders in child-linkage table rows that no
+        # downstream code currently expands.  Substitute neutral text so
+        # the P0-4 scanner doesn't flag these cosmetic sample rows.
+        "[DATE]": _dt.date.today().isoformat(),
+        "[DESCRIPTION]": "_(child linkage populated after creation)_",
     }
 
     rendered = template_text
     for placeholder, value in replacements.items():
         rendered = rendered.replace(placeholder, value)
 
+    # ----- phase 2: per-level subsection fillers (Stage 2) -----
+    section_fillers: dict[str, Any] = {
+        "scope": _fill_scope_subsections,
+        "initiative": _fill_initiative_subsections,
+        "epic": _fill_epic_subsections,
+        "story": _fill_story_subsections,
+        "task": _fill_task_subsections,
+    }
+    filler = section_fillers.get(level)
+    if filler is not None:
+        rendered = filler(rendered, subs)
+
     # Inject parent reference for levels that have one
     if parent and level in ("epic", "story", "task"):
         if "> **Parent" not in rendered:
-            # Add parent ref after the first heading line
             lines = rendered.split("\n", 1)
             if len(lines) == 2:
                 parent_labels = {
@@ -491,6 +826,428 @@ def _render_template(template_text: str, item: dict[str, Any], level: str) -> st
                 }
                 label = parent_labels.get(level, "Parent")
                 rendered = f"{lines[0]}\n\n> **{label}**: {parent}\n{lines[1]}"
+
+    return rendered
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 (FR #34): Per-level subsection fillers.
+#
+# Each filler function receives the template text after phase-1 metadata
+# substitution + the item's structured subsection dict.  It replaces each
+# placeholder BLOCK (not just the first keyword) with the subsection
+# content when available, or leaves the placeholder intact when the plan
+# didn't provide that subsection (Stage 1 scanner catches leaks; Stage 4
+# will replace remaining placeholders with a TBD marker).
+# ---------------------------------------------------------------------------
+
+
+def _bullet_lines(items: list[str], checkbox: bool = False) -> str:
+    """Format a bullet list as markdown. `checkbox=True` prepends `- [ ]`."""
+    prefix = "- [ ] " if checkbox else "- "
+    return "\n".join(f"{prefix}{i}" for i in items)
+
+
+def _replace_block(rendered: str, old_block: str, new_block: str) -> str:
+    """Replace a verbatim block; no-op when the block isn't present."""
+    if old_block in rendered:
+        return rendered.replace(old_block, new_block, 1)
+    return rendered
+
+
+def _moscow_table_rows(moscow: dict[str, list[str]]) -> str:
+    """Render MoSCoW groups as table rows.  Empty groups keep placeholder."""
+    rows: list[str] = []
+    group_order = [
+        ("must_have", "Must Have"),
+        ("should_have", "Should Have"),
+        ("could_have", "Could Have"),
+        ("wont_have", "Won't Have"),
+    ]
+    for key, label in group_order:
+        items = moscow.get(key) or []
+        if not items:
+            rows.append(f"| {label} | [ITEM] |")
+        else:
+            for item in items:
+                rows.append(f"| {label} | {item} |")
+    return "\n".join(rows)
+
+
+def _fill_scope_subsections(rendered: str, subs: dict[str, Any]) -> str:
+    # Business Problem
+    bp = subs.get("business_problem")
+    if isinstance(bp, str) and bp.strip():
+        rendered = rendered.replace(
+            "[Describe the problem being solved and why the current "
+            "approach is insufficient]",
+            bp,
+        )
+
+    # Success Criteria
+    crit = subs.get("success_criteria") or []
+    if crit:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [CRITERION 1]\n- [ ] [CRITERION 2]",
+            _bullet_lines(crit, checkbox=True),
+        )
+
+    # In-Scope Capabilities
+    in_scope = subs.get("in_scope_capabilities")
+    if in_scope:
+        in_scope_text = (
+            in_scope if isinstance(in_scope, str) else _bullet_lines(in_scope)
+        )
+        rendered = rendered.replace(
+            "[List of features or capabilities included, with references "
+            "to Initiatives/Epics]",
+            in_scope_text,
+        )
+
+    # Assumptions
+    assumptions = subs.get("assumptions") or []
+    if assumptions:
+        rendered = _replace_block(
+            rendered,
+            "- [ASSUMPTION 1]\n- [ASSUMPTION 2]",
+            _bullet_lines(assumptions),
+        )
+
+    # Out of Scope
+    oos = subs.get("out_of_scope") or []
+    if oos:
+        rendered = _replace_block(
+            rendered,
+            "- [ITEM 1]\n- [ITEM 2]",
+            _bullet_lines(oos),
+        )
+
+    # MoSCoW
+    moscow = subs.get("moscow") or {}
+    if isinstance(moscow, dict) and moscow:
+        old_rows = (
+            "| Must Have | [ITEM] |\n"
+            "| Should Have | [ITEM] |\n"
+            "| Could Have | [ITEM] |\n"
+            "| Won't Have | [ITEM] |"
+        )
+        rendered = _replace_block(rendered, old_rows, _moscow_table_rows(moscow))
+
+    # Done When (project-specific criterion)
+    done = subs.get("done_when") or []
+    if done:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [PROJECT-SPECIFIC CRITERION]",
+            _bullet_lines(done, checkbox=True),
+        )
+
+    return rendered
+
+
+def _fill_initiative_subsections(rendered: str, subs: dict[str, Any]) -> str:
+    # Release Value
+    rv = subs.get("release_value")
+    if isinstance(rv, str) and rv.strip():
+        rendered = rendered.replace(
+            "[What becomes possible after this initiative ships — 1-2 sentences]",
+            rv,
+        )
+
+    # Success Criteria
+    crit = subs.get("success_criteria") or []
+    if crit:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [CRITERION 1]\n- [ ] [CRITERION 2]",
+            _bullet_lines(crit, checkbox=True),
+        )
+
+    # Feature Scope (raw paragraph or bullets → single-column rows)
+    fs = subs.get("feature_scope")
+    if fs:
+        fs_block = fs if isinstance(fs, str) else _bullet_lines(fs)
+        rendered = _replace_block(
+            rendered,
+            "| 1 | [FEATURE] | [INCLUDES] | [ENABLES] |",
+            fs_block,
+        )
+
+    # Assumptions
+    assumptions = subs.get("assumptions") or []
+    if assumptions:
+        rendered = _replace_block(
+            rendered,
+            "- [ASSUMPTION 1]\n- [ASSUMPTION 2]",
+            _bullet_lines(assumptions),
+        )
+
+    # Dependencies
+    deps = subs.get("dependencies")
+    if deps:
+        deps_block = deps if isinstance(deps, str) else _bullet_lines(deps)
+        rendered = _replace_block(
+            rendered,
+            "| [DEPENDENCY] | [TYPE] | [OWNER] | [STATUS] |",
+            deps_block,
+        )
+
+    # Out of Scope
+    oos = subs.get("out_of_scope") or []
+    if oos:
+        rendered = _replace_block(
+            rendered,
+            "- [ITEM]",
+            _bullet_lines(oos),
+        )
+
+    # Artifacts
+    art = subs.get("artifacts") or []
+    if art:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [ARTIFACT]",
+            _bullet_lines(art, checkbox=True),
+        )
+
+    # Done When
+    done = subs.get("done_when") or []
+    if done:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [PROJECT-SPECIFIC CRITERION]",
+            _bullet_lines(done, checkbox=True),
+        )
+
+    return rendered
+
+
+def _fill_epic_subsections(rendered: str, subs: dict[str, Any]) -> str:
+    # Release Value
+    rv = subs.get("release_value")
+    if isinstance(rv, str) and rv.strip():
+        rendered = rendered.replace(
+            "[What becomes possible after this epic ships — 1-2 sentences]",
+            rv,
+        )
+
+    # Success Criteria
+    crit = subs.get("success_criteria") or []
+    if crit:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [CRITERION 1]\n- [ ] [CRITERION 2]",
+            _bullet_lines(crit, checkbox=True),
+        )
+
+    # Feature Scope
+    fs = subs.get("feature_scope")
+    if fs:
+        fs_block = fs if isinstance(fs, str) else _bullet_lines(fs)
+        rendered = _replace_block(
+            rendered,
+            "| 1 | [FEATURE] | [INCLUDES] | [ENABLES] |",
+            fs_block,
+        )
+
+    # Assumptions
+    assumptions = subs.get("assumptions") or []
+    if assumptions:
+        rendered = _replace_block(
+            rendered,
+            "- [ASSUMPTION 1]",
+            _bullet_lines(assumptions),
+        )
+
+    # Dependencies
+    deps = subs.get("dependencies")
+    if deps:
+        deps_block = deps if isinstance(deps, str) else _bullet_lines(deps)
+        rendered = _replace_block(
+            rendered,
+            "| [DEPENDENCY] | [TYPE] | [OWNER] | [STATUS] |",
+            deps_block,
+        )
+
+    # Done When
+    done = subs.get("done_when") or []
+    if done:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [PROJECT-SPECIFIC CRITERION]",
+            _bullet_lines(done, checkbox=True),
+        )
+
+    # Code Areas
+    ca = subs.get("code_areas")
+    if ca:
+        ca_block = ca if isinstance(ca, str) else _bullet_lines(ca)
+        rendered = _replace_block(
+            rendered,
+            "| [TYPE] | [OBJECT] | [LOCATION] | [NOTES] |",
+            ca_block,
+        )
+
+    # Questions for Tech Lead
+    qs = subs.get("questions_tech_lead") or []
+    if qs:
+        rendered = _replace_block(rendered, "- [QUESTION]", _bullet_lines(qs))
+
+    # Security/Compliance
+    sc = subs.get("security_compliance")
+    if isinstance(sc, str) and sc.strip():
+        rendered = rendered.replace(
+            "[Required if this epic involves create/update/delete/"
+            "resolve/write operations]",
+            sc,
+        )
+
+    return rendered
+
+
+def _fill_story_subsections(rendered: str, subs: dict[str, Any]) -> str:
+    # User Story block
+    us = subs.get("user_story")
+    if isinstance(us, str) and us.strip():
+        old = "As a [ROLE],\nI want [WHAT],\nSo that [OUTCOME]."
+        rendered = _replace_block(rendered, old, us.strip())
+
+    # Why This Matters
+    wtm = subs.get("why_this_matters")
+    if isinstance(wtm, str) and wtm.strip():
+        rendered = rendered.replace(
+            "[Why this story is needed and what breaks without it — 2-3 sentences]",
+            wtm,
+        )
+
+    # Assumptions (story has a special 3-line format)
+    assumptions = subs.get("assumptions") or []
+    if assumptions:
+        old_block = (
+            "- **Roles**: [WHO uses the output of this story]\n"
+            "- **Starting point**: [Preconditions that must be true]\n"
+            "- **Preconditions**: [What must exist before this story starts]"
+        )
+        rendered = _replace_block(rendered, old_block, _bullet_lines(assumptions))
+
+    # MoSCoW
+    moscow = subs.get("moscow") or {}
+    if isinstance(moscow, dict) and moscow:
+        old_rows = (
+            "| Must Have | [ITEM] |\n"
+            "| Should Have | [ITEM] |\n"
+            "| Could Have | [ITEM] |\n"
+            "| Won't Have | [ITEM] |"
+        )
+        rendered = _replace_block(rendered, old_rows, _moscow_table_rows(moscow))
+
+    # Dependencies
+    deps = subs.get("dependencies")
+    if deps:
+        deps_block = deps if isinstance(deps, str) else _bullet_lines(deps)
+        rendered = _replace_block(
+            rendered,
+            "| #[N] | [DESCRIPTION] | [STATUS] |",
+            deps_block,
+        )
+
+    # Done When
+    done = subs.get("done_when") or []
+    if done:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [ACCEPTANCE CRITERION 1]\n- [ ] [ACCEPTANCE CRITERION 2]",
+            _bullet_lines(done, checkbox=True),
+        )
+
+    # Acceptance Criteria (scenarios)
+    ac = subs.get("acceptance_criteria")
+    if isinstance(ac, str) and ac.strip():
+        old_block = (
+            "**Scenario 1**: [SCENARIO NAME]\n"
+            "- **Given**: [PRECONDITION]\n"
+            "- **When**: [ACTION]\n"
+            "- **Then**: [EXPECTED OUTCOME]"
+        )
+        rendered = _replace_block(rendered, old_block, ac.strip())
+
+    # Constraints
+    constraints = subs.get("constraints") or []
+    if constraints:
+        rendered = _replace_block(
+            rendered,
+            "- [CONSTRAINT]",
+            _bullet_lines(constraints),
+        )
+
+    # Implementation Notes
+    impl = subs.get("implementation_notes")
+    if isinstance(impl, str) and impl.strip():
+        rendered = rendered.replace(
+            "[Technical approach, key considerations]",
+            impl,
+        )
+
+    # Security/Compliance
+    sc = subs.get("security_compliance")
+    if isinstance(sc, str) and sc.strip():
+        rendered = rendered.replace(
+            "[Required if story involves create/update/delete/"
+            "resolve/write operations]",
+            sc,
+        )
+
+    # Subtasks Needed
+    st = subs.get("subtasks_needed")
+    if st:
+        st_block = st if isinstance(st, str) else _bullet_lines(st)
+        rendered = _replace_block(
+            rendered,
+            "| 1 | [TASK] | [PTS] | [YES/NO] |",
+            st_block,
+        )
+
+    return rendered
+
+
+def _fill_task_subsections(rendered: str, subs: dict[str, Any]) -> str:
+    # Context block
+    ctx = subs.get("context") or []
+    if ctx:
+        old_block = (
+            '- **Parent Story AC**: "[The acceptance criterion this '
+            'task satisfies]"\n'
+            "- **Preceding Task**: [#N task that must complete first, or None]\n"
+            "- **Blocking Tasks**: [#N tasks blocked by this one]"
+        )
+        rendered = _replace_block(rendered, old_block, _bullet_lines(ctx))
+
+    # Done When (technical criteria)
+    done = subs.get("done_when") or []
+    if done:
+        rendered = _replace_block(
+            rendered,
+            "- [ ] [TECHNICAL CRITERION 1]\n- [ ] [TECHNICAL CRITERION 2]",
+            _bullet_lines(done, checkbox=True),
+        )
+
+    # Implementation Notes
+    impl = subs.get("implementation_notes")
+    if isinstance(impl, str) and impl.strip():
+        rendered = rendered.replace(
+            "[How to implement this — pseudocode or concrete steps]",
+            impl,
+        )
+
+    # Security/Compliance
+    sc = subs.get("security_compliance")
+    if isinstance(sc, str) and sc.strip():
+        rendered = rendered.replace(
+            "[Required if task involves create/update/delete/"
+            "resolve/write operations]",
+            sc,
+        )
 
     return rendered
 
@@ -1035,6 +1792,32 @@ def _flatten_parsed_hierarchy(hierarchy: dict[str, Any]) -> dict[str, dict[str, 
     return items_by_title
 
 
+def _unified_diff_snippet(
+    before: str, after: str, issue_number: int, max_lines: int = 200
+) -> str:
+    """Return a unified diff between before/after bodies, capped at `max_lines`.
+
+    Keeps the diff short enough to be readable in a report without
+    ballooning the JSON.  When truncated, appends a `... [truncated]`
+    marker so the operator knows there's more.
+    """
+    import difflib
+
+    diff = difflib.unified_diff(
+        before.splitlines(keepends=False),
+        after.splitlines(keepends=False),
+        fromfile=f"issue-{issue_number}-before",
+        tofile=f"issue-{issue_number}-after",
+        lineterm="",
+        n=3,
+    )
+    lines = list(diff)
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines.append(f"... [truncated at {max_lines} lines]")
+    return "\n".join(lines)
+
+
 def refresh_backlog(
     plan_path: str,
     repo: str,
@@ -1148,6 +1931,11 @@ def refresh_backlog(
         per_issue_record["status"] = "updated" if not dry_run else "would-update"
         per_issue_record["diff_chars_before"] = len(current_body)
         per_issue_record["diff_chars_after"] = len(new_body)
+
+        # Stage 2 (FR #34): include a real unified diff in the report so
+        # operators can review exactly what would change before running
+        # `--apply` instead of trusting a single char-count delta.
+        per_issue_record["diff"] = _unified_diff_snippet(current_body, new_body, number)
 
         if dry_run:
             report["summary"]["updated"] += 1

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -973,6 +973,23 @@ class TestRefreshMode:
         # dry_run → update_issue_body NEVER called
         update_mock.assert_not_called()
         assert report["per_issue"][0]["status"] == "would-update"
+        # Stage 2d: report now includes a unified diff (not just char counts)
+        assert "diff" in report["per_issue"][0]
+        diff_text = report["per_issue"][0]["diff"]
+        assert "issue-182-before" in diff_text
+        assert "issue-182-after" in diff_text
+        assert "OLD BODY" in diff_text  # the removed line shows in the diff
+
+    def test_unified_diff_snippet_truncates_long_diffs(self):
+        """Diffs longer than max_lines are capped with a truncation marker."""
+        from scripts import create_issues
+
+        before = "\n".join(f"line {i}" for i in range(500))
+        after = "\n".join(f"changed {i}" for i in range(500))
+        diff = create_issues._unified_diff_snippet(before, after, 42, max_lines=50)
+        assert "[truncated at 50 lines]" in diff
+        # Sanity: the truncated diff is still a valid unified-diff prefix.
+        assert diff.startswith("--- issue-42-before")
 
     def test_refresh_backlog_apply_mode_calls_update(self, mocker, tmp_path):
         """apply mode (dry_run=False) invokes update_issue_body."""
@@ -1786,3 +1803,445 @@ class TestFindByRef:
         }
         result = set_relationships._find_by_ref("Nonexistent", by_title)
         assert result is None
+
+
+# ===========================================================================
+# FR #34 Stage 2: Structured subsection parser + per-level renderers
+# ===========================================================================
+
+
+class TestSubsectionParser:
+    """Parser: extract `#### Section Name` subsections from item bodies."""
+
+    def test_returns_empty_dict_for_blank_body(self):
+        from scripts import create_issues
+
+        assert create_issues._parse_subsections("", "scope") == {}
+
+    def test_stores_leading_text_when_no_subsections_present(self):
+        from scripts import create_issues
+
+        subs = create_issues._parse_subsections(
+            "Just a prose description.\nNo subsections.",
+            "scope",
+        )
+        assert subs == {
+            "_leading_text": "Just a prose description.\nNo subsections.",
+        }
+
+    def test_extracts_single_paragraph_subsection(self):
+        from scripts import create_issues
+
+        body = (
+            "Intro paragraph.\n\n"
+            "#### Business Problem\n\n"
+            "Legacy approach uses N+1 queries and burns 3x the CPU.\n"
+        )
+        subs = create_issues._parse_subsections(body, "scope")
+        assert subs["_leading_text"] == "Intro paragraph."
+        assert (
+            subs["business_problem"]
+            == "Legacy approach uses N+1 queries and burns 3x the CPU."
+        )
+
+    def test_extracts_bullet_subsection_as_list(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Success Criteria\n\n"
+            "- [ ] Metric A hits target\n"
+            "- [ ] Metric B unchanged\n"
+            "- Metric C captured in dashboard\n"
+        )
+        subs = create_issues._parse_subsections(body, "scope")
+        assert subs["success_criteria"] == [
+            "Metric A hits target",
+            "Metric B unchanged",
+            "Metric C captured in dashboard",
+        ]
+
+    def test_extracts_moscow_nested_groups(self):
+        from scripts import create_issues
+
+        body = (
+            "#### MoSCoW\n\n"
+            "**Must Have**:\n"
+            "- Token metering\n"
+            "- Admin dashboard\n\n"
+            "**Should Have**:\n"
+            "- Realtime alerts\n\n"
+            "**Could Have**:\n"
+            "- Slack integration\n\n"
+            "**Won't Have**:\n"
+            "- Per-user throttling (this release)\n"
+        )
+        subs = create_issues._parse_subsections(body, "scope")
+        assert subs["moscow"] == {
+            "must_have": ["Token metering", "Admin dashboard"],
+            "should_have": ["Realtime alerts"],
+            "could_have": ["Slack integration"],
+            "wont_have": ["Per-user throttling (this release)"],
+        }
+
+    def test_heading_aliases_are_case_insensitive(self):
+        from scripts import create_issues
+
+        body = "### BUSINESS PROBLEM & CURRENT STATE\n\nfoo\n"
+        subs = create_issues._parse_subsections(body, "scope")
+        assert subs.get("business_problem") == "foo"
+
+    def test_unrecognized_heading_stays_as_content(self):
+        from scripts import create_issues
+
+        body = "#### Implementation Notes\n\n" "### Approach\n\n" "Do X then Y.\n"
+        subs = create_issues._parse_subsections(body, "task")
+        # Unrecognized `### Approach` is not a new subsection — it remains
+        # inside Implementation Notes as content.
+        assert "### Approach" in subs["implementation_notes"]
+        assert "Do X then Y." in subs["implementation_notes"]
+
+    def test_bullet_variants_all_recognized(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Assumptions\n\n"
+            "- dash bullet\n"
+            "* star bullet\n"
+            "- [ ] checkbox unchecked\n"
+            "- [x] checkbox checked\n"
+        )
+        subs = create_issues._parse_subsections(body, "scope")
+        assert subs["assumptions"] == [
+            "dash bullet",
+            "star bullet",
+            "checkbox unchecked",
+            "checkbox checked",
+        ]
+
+    def test_paragraph_in_bullet_section_wraps_as_single_item(self):
+        from scripts import create_issues
+
+        # If the author wrote prose under a bullet-expected subsection,
+        # the parser should still capture something rather than drop it.
+        body = (
+            "#### Out of Scope\n\n"
+            "Anything involving the legacy API is explicitly out.\n"
+        )
+        subs = create_issues._parse_subsections(body, "scope")
+        assert subs["out_of_scope"] == [
+            "Anything involving the legacy API is explicitly out.",
+        ]
+
+    def test_parses_initiative_specific_keys(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Objective\nWhy it exists.\n\n"
+            "#### Release Value\nWhat ships.\n\n"
+            "#### Artifacts\n- Runbook\n- Dashboard\n"
+        )
+        subs = create_issues._parse_subsections(body, "initiative")
+        assert subs["objective"] == "Why it exists."
+        assert subs["release_value"] == "What ships."
+        assert subs["artifacts"] == ["Runbook", "Dashboard"]
+
+    def test_parses_task_specific_keys(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Summary\nImplement the thing.\n\n"
+            "#### Context\n"
+            "- Parent AC: X\n"
+            "- Preceding: #5\n"
+        )
+        subs = create_issues._parse_subsections(body, "task")
+        assert subs["summary"] == "Implement the thing."
+        assert subs["context"] == ["Parent AC: X", "Preceding: #5"]
+
+
+class TestRenderScopeSubsections:
+    """Renderer: scope template placeholders filled from subsections."""
+
+    def _scope_item(self, body: str) -> dict:
+        from scripts import create_issues
+
+        return {
+            "title": "Test scope",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "subsections": create_issues._parse_subsections(body, "scope"),
+        }
+
+    def test_success_criteria_replaces_placeholder_block(self):
+        from scripts import create_issues
+
+        item = self._scope_item(
+            "#### Success Criteria\n- All providers reach parity\n- CI stays green\n"
+        )
+        body = create_issues.generate_body(item, "scope")
+        assert "[CRITERION 1]" not in body
+        assert "[CRITERION 2]" not in body
+        assert "- [ ] All providers reach parity" in body
+        assert "- [ ] CI stays green" in body
+
+    def test_business_problem_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._scope_item("#### Business Problem\nLegacy path cannot meet SLA.\n")
+        body = create_issues.generate_body(item, "scope")
+        assert "[Describe the problem" not in body
+        assert "Legacy path cannot meet SLA." in body
+
+    def test_assumptions_replaces_placeholder_block(self):
+        from scripts import create_issues
+
+        item = self._scope_item(
+            "#### Assumptions\n- gh CLI is available\n- Tokens are valid\n"
+        )
+        body = create_issues.generate_body(item, "scope")
+        assert "[ASSUMPTION 1]" not in body
+        assert "[ASSUMPTION 2]" not in body
+        assert "- gh CLI is available" in body
+
+    def test_out_of_scope_replaces_placeholder_block(self):
+        from scripts import create_issues
+
+        item = self._scope_item("#### Out of Scope\n- Windows supervisor\n")
+        body = create_issues.generate_body(item, "scope")
+        assert "[ITEM 1]" not in body
+        assert "[ITEM 2]" not in body
+        assert "- Windows supervisor" in body
+
+    def test_moscow_replaces_table_rows(self):
+        from scripts import create_issues
+
+        item = self._scope_item(
+            "#### MoSCoW\n\n"
+            "**Must Have**:\n- Token metering\n\n"
+            "**Should Have**:\n- Alerts\n\n"
+            "**Could Have**:\n- Slack bot\n\n"
+            "**Won't Have**:\n- Throttling\n"
+        )
+        body = create_issues.generate_body(item, "scope")
+        assert "| Must Have | [ITEM] |" not in body
+        assert "| Must Have | Token metering |" in body
+        assert "| Should Have | Alerts |" in body
+        assert "| Could Have | Slack bot |" in body
+        assert "| Won't Have | Throttling |" in body
+
+    def test_done_when_replaces_project_specific_criterion(self):
+        from scripts import create_issues
+
+        item = self._scope_item(
+            "#### I Know I Am Done When\n- Dashboard live in prod\n"
+        )
+        body = create_issues.generate_body(item, "scope")
+        assert "[PROJECT-SPECIFIC CRITERION]" not in body
+        assert "- [ ] Dashboard live in prod" in body
+
+    def test_backward_compat_no_subsections_keeps_placeholders(self):
+        """Plans without subsections get the same behavior as pre-Stage-2."""
+        from scripts import create_issues
+
+        item = self._scope_item("Just a prose description with no subsections.")
+        body = create_issues.generate_body(item, "scope")
+        # Placeholders should still be present (Stage 1 scanner catches them).
+        assert "[CRITERION 1]" in body or "- [ ] [CRITERION" in body
+        assert "[ASSUMPTION 1]" in body or "- [ASSUMPTION" in body
+        # But vision/leading text should be populated from the description.
+        assert "Just a prose description" in body
+
+
+class TestRenderInitiativeSubsections:
+    def _init_item(self, body: str) -> dict:
+        from scripts import create_issues
+
+        return {
+            "title": "Test initiative",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "subsections": create_issues._parse_subsections(body, "initiative"),
+        }
+
+    def test_release_value_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._init_item(
+            "#### Release Value\nTeams can bill per-user for inference.\n"
+        )
+        body = create_issues.generate_body(item, "initiative")
+        assert "Teams can bill per-user for inference." in body
+        assert "[What becomes possible after this initiative ships" not in body
+
+    def test_artifacts_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._init_item("#### Artifacts\n- Runbook\n- Dashboard\n")
+        body = create_issues.generate_body(item, "initiative")
+        assert "[ARTIFACT]" not in body
+        assert "- [ ] Runbook" in body
+        assert "- [ ] Dashboard" in body
+
+
+class TestRenderEpicSubsections:
+    def _epic_item(self, body: str) -> dict:
+        from scripts import create_issues
+
+        return {
+            "title": "Test epic",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "parent_ref": "Test initiative",
+            "subsections": create_issues._parse_subsections(body, "epic"),
+        }
+
+    def test_release_value_uses_epic_specific_placeholder(self):
+        from scripts import create_issues
+
+        item = self._epic_item("#### Release Value\nNew dashboard page.\n")
+        body = create_issues.generate_body(item, "epic")
+        assert "New dashboard page." in body
+        assert "[What becomes possible after this epic ships" not in body
+
+    def test_questions_for_tech_lead_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._epic_item(
+            "#### Questions for Tech Lead\n- Sync or async cache?\n- HTTP/2?\n"
+        )
+        body = create_issues.generate_body(item, "epic")
+        assert "- [QUESTION]" not in body
+        assert "- Sync or async cache?" in body
+
+
+class TestRenderStorySubsections:
+    def _story_item(self, body: str) -> dict:
+        from scripts import create_issues
+
+        return {
+            "title": "Test story",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "parent_ref": "Test epic",
+            "subsections": create_issues._parse_subsections(body, "story"),
+        }
+
+    def test_user_story_block_replaces_as_a_template(self):
+        from scripts import create_issues
+
+        item = self._story_item(
+            "#### User Story\n"
+            "As a finance lead,\n"
+            "I want monthly cost reports,\n"
+            "So that I can chargeback.\n"
+        )
+        body = create_issues.generate_body(item, "story")
+        assert "As a [ROLE]" not in body
+        assert "As a finance lead" in body
+
+    def test_why_this_matters_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._story_item("#### Why This Matters\nCosts are untracked today.\n")
+        body = create_issues.generate_body(item, "story")
+        assert "[Why this story is needed" not in body
+        assert "Costs are untracked today." in body
+
+    def test_constraints_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._story_item("#### Constraints\n- Must ship before Q2\n")
+        body = create_issues.generate_body(item, "story")
+        assert "- [CONSTRAINT]" not in body
+        assert "- Must ship before Q2" in body
+
+
+class TestRenderTaskSubsections:
+    def _task_item(self, body: str) -> dict:
+        from scripts import create_issues
+
+        return {
+            "title": "Test task",
+            "description": body,
+            "priority": "P1",
+            "size": "S",
+            "parent_ref": "Test story",
+            "subsections": create_issues._parse_subsections(body, "task"),
+        }
+
+    def test_context_replaces_placeholder_block(self):
+        from scripts import create_issues
+
+        item = self._task_item(
+            "#### Context\n"
+            '- Parent AC: "cost report generates on schedule"\n'
+            "- Preceding: #12\n"
+            "- Blocks: #15\n"
+        )
+        body = create_issues.generate_body(item, "task")
+        assert "[The acceptance criterion this task satisfies]" not in body
+        assert '- Parent AC: "cost report generates on schedule"' in body
+
+    def test_implementation_notes_replaces_placeholder(self):
+        from scripts import create_issues
+
+        item = self._task_item(
+            "#### Implementation Notes\n\n### Approach\n" "Use regex then pandas.\n"
+        )
+        body = create_issues.generate_body(item, "task")
+        assert "[How to implement this" not in body
+        assert "Use regex then pandas." in body
+
+
+class TestEndToEndPlanRender:
+    """End-to-end: parse a full structured plan and verify no placeholder leaks."""
+
+    def test_fully_structured_plan_has_no_placeholder_strings(self, tmp_path):
+        """Given a plan with every subsection populated, the rendered
+        scope body should contain no unreplaced bracket placeholders.
+        """
+        from scripts import compliance_check, create_issues
+
+        plan_body = (
+            "# Project Scope: PS-TEST — End-to-end verification\n\n"
+            "Priority: P0\nSize: M\n\n"
+            "The end state is a fully-populated scope body with zero placeholders.\n\n"
+            "#### Business Problem\n\n"
+            "Today, scopes ship with template placeholder strings.\n\n"
+            "#### Success Criteria\n\n"
+            "- All subsections populate from plan\n"
+            "- Scanner reports zero P0-4 gaps\n\n"
+            "#### In-Scope Capabilities\n\n"
+            "- Subsection parser\n"
+            "- Per-level renderers\n\n"
+            "#### Assumptions\n\n"
+            "- gh CLI is available\n"
+            "- Tokens are valid\n\n"
+            "#### Out of Scope\n\n"
+            "- Windows supervisor\n\n"
+            "#### MoSCoW\n\n"
+            "**Must Have**:\n- Token metering\n\n"
+            "**Should Have**:\n- Realtime alerts\n\n"
+            "**Could Have**:\n- Slack bot\n\n"
+            "**Won't Have**:\n- Per-user throttling\n\n"
+            "#### I Know I Am Done When\n\n"
+            "- Scope renders with no placeholders\n"
+        )
+        plan_path = tmp_path / "plan.md"
+        plan_path.write_text(plan_body, encoding="utf-8")
+
+        hierarchy = create_issues.parse_plan(str(plan_path))
+        scope = hierarchy["scope"]
+        body = create_issues.generate_body(scope, "scope")
+
+        # Per Stage 1: the P0-4 scanner must not flag this as incomplete
+        gaps = compliance_check.check_issue(1, scope["title"], body, "scope")
+        p0_4 = [g for g in gaps if g["rule"] == "P0-4"]
+        assert not p0_4, (
+            f"Unexpected placeholder gaps after full render: "
+            f"{[g.get('placeholders') for g in p0_4]}"
+        )


### PR DESCRIPTION
## Summary

- Plans may now opt into `#### Section Name` subsections that map 1:1 to template placeholder groups (scope / initiative / epic / story / task).
- New parser extracts canonical subsections (e.g. `business_problem`, `success_criteria`, `moscow` with Must/Should/Could/Won't groups, `done_when`) with case-insensitive alias matching.
- New per-level filler functions replace the old flat `_render_template` substitution with proper block-level placeholder filling, so shipped bodies contain real content instead of `[CRITERION 1]` / `[ASSUMPTION 1]` / `[ITEM 1]` leaks.
- `refresh` report now includes a real unified diff (not just char counts) per would-update via `_unified_diff_snippet()`.
- Cosmetic fixes: `[DATE]` → today's ISO date; `[DESCRIPTION]` in the Scope Initiatives-table sample row → `_(child linkage populated after creation)_` so the P0-4 scanner stops flagging it.

## Backward compatibility

Plans without subsection headings continue to render identically to pre-Stage-2 behavior. The item's raw body populates the primary narrative field (Vision for scope, Objective for initiative/epic, TL;DR for story, Summary for task). Adoption is per-plan.

## Docs

- `SKILL.md` gains a "Refresh" section + subsection schema table
- `references/plan-format.md` gains a "Structured Subsections" section with per-level heading names, MoSCoW format, full example, and backward-compat notes

## Test plan

- [x] 28 new Stage 2 tests (parser, scope/initiative/epic/story/task renderers, end-to-end placeholder-free render)
- [x] 1 new refresh unified-diff test
- [x] Full suite: 338/338 passing, 83.67% coverage
- [x] `ruff check` + `ruff format` clean
- [ ] Post-merge end-to-end: reinstall skill and run `refresh --dry-run --scope-issue 182 --repo kdtix-open/agent-project-queue` — verify no `[PLACEHOLDER]` strings leak in the generated bodies

## Next (follow-on PRs)

- **Stage 3**: `--interactive` flag for missing subsections
- **Stage 4**: TBD fallback (replace remaining `[PLACEHOLDER]` with `_TBD — not provided_`)

Refs #34 Stage 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)