### PR TITLE
feat(refresh): preserve outside-template content (FR #34 Stage 2.5)

### DIFF
--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -1792,6 +1792,70 @@ def _flatten_parsed_hierarchy(hierarchy: dict[str, Any]) -> dict[str, dict[str, 
     return items_by_title
 
 
+def _preserve_outside_template_zone(
+    existing_body: str, new_body: str
+) -> tuple[str, dict[str, str]]:
+    """Merge operator-authored prefix/suffix from `existing_body` into `new_body`.
+
+    The skill's templates define a canonical rendered body that starts with
+    `# <Level>: <Title>` and (for scope) ends with a `_Created: ... | Owner: ..._`
+    footer.  Anything OUTSIDE that zone in the existing body — HTML comments,
+    sequence-order blockquotes, trailing signatures, custom tooling markers —
+    is operator-authored content the skill does not own.
+
+    This function:
+     1. Extracts the prefix (lines before the first `# ` heading) from
+        `existing_body`.
+     2. Extracts the suffix (lines after the last italic `_Created: ..._`
+        footer, if any) from `existing_body`.
+     3. Prepends the prefix + appends the suffix to `new_body`, BUT only
+        when `new_body` does not already contain that exact content
+        (idempotent: re-runs don't duplicate the prefix).
+
+    Returns `(merged_body, {"prefix": <extracted>, "suffix": <extracted>})`.
+    The returned dict lets callers log/report what was preserved.
+    """
+    prefix = ""
+    suffix = ""
+
+    # --- prefix: content before the first top-level heading -----------------
+    # Using re.MULTILINE so `^# ` matches at the start of any line.
+    existing_heading_match = re.search(r"^# [^\n]+$", existing_body, re.MULTILINE)
+    if existing_heading_match:
+        idx = existing_heading_match.start()
+        candidate_prefix = existing_body[:idx].rstrip("\n")
+        if candidate_prefix.strip():
+            prefix = candidate_prefix
+
+    # --- suffix: content after the last `_Created: ... | Owner: ..._` footer
+    # Using a forgiving pattern: italic span that starts with `_Created:` and
+    # ends with `_`.  Only matches when present; scope templates have it,
+    # other levels typically don't.
+    created_footer = re.compile(r"^_Created:[^\n]*_$", re.MULTILINE)
+    existing_footers = list(created_footer.finditer(existing_body))
+    if existing_footers:
+        last = existing_footers[-1]
+        candidate_suffix = existing_body[last.end() :].lstrip("\n")
+        if candidate_suffix.strip():
+            suffix = candidate_suffix
+
+    # --- merge (idempotent) --------------------------------------------------
+    merged = new_body
+    if prefix and prefix not in merged:
+        merged = f"{prefix}\n\n{merged}"
+    if suffix and suffix not in merged:
+        # Append after the footer of the NEW body if it has one; else just
+        # at the end.
+        new_footer_match = list(created_footer.finditer(merged))
+        if new_footer_match:
+            insert_at = new_footer_match[-1].end()
+            merged = merged[:insert_at].rstrip() + "\n\n" + suffix.strip() + "\n"
+        else:
+            merged = merged.rstrip() + "\n\n" + suffix.strip() + "\n"
+
+    return merged, {"prefix": prefix, "suffix": suffix}
+
+
 def _unified_diff_snippet(
     before: str, after: str, issue_number: int, max_lines: int = 200
 ) -> str:
@@ -1920,6 +1984,21 @@ def refresh_backlog(
             continue
 
         new_body = generate_body(item, level)
+
+        # Stage 2.5 (FR #34): preserve operator-authored content that lives
+        # OUTSIDE the template zone — anything before the first `# Heading`
+        # and anything after the closing `_Created: ..._` footer.  This
+        # protects tooling markers (HTML comments), sequence-order
+        # blockquotes, signatures, and other annotations that the skill's
+        # templates don't own + shouldn't clobber on refresh.
+        new_body, preserved = _preserve_outside_template_zone(current_body, new_body)
+        if preserved["prefix"] or preserved["suffix"]:
+            per_issue_record["preserved"] = {
+                "prefix_lines": preserved["prefix"].count("\n")
+                + (1 if preserved["prefix"] else 0),
+                "suffix_lines": preserved["suffix"].count("\n")
+                + (1 if preserved["suffix"] else 0),
+            }
 
         if current_body.strip() == new_body.strip():
             per_issue_record["status"] = "unchanged"

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -980,6 +980,68 @@ class TestRefreshMode:
         assert "issue-182-after" in diff_text
         assert "OLD BODY" in diff_text  # the removed line shows in the diff
 
+    def test_preserve_outside_zone_keeps_html_comment_prefix(self):
+        """Stage 2.5: HTML comment + blockquote before `# Heading` survive refresh."""
+        from scripts import create_issues
+
+        existing = (
+            "<!-- scope-sequence-order: 1 -->\n\n"
+            "> **Sequence Order: 1** — operator-declared ship-order.  "
+            "Read by Story #250 parser.\n\n"
+            "# Project Scope: Test\n\n"
+            "Body content here.\n"
+        )
+        new = "# Project Scope: Test\n\nFreshly rendered body.\n"
+        merged, preserved = create_issues._preserve_outside_template_zone(existing, new)
+        assert "<!-- scope-sequence-order: 1 -->" in merged
+        assert "**Sequence Order: 1**" in merged
+        assert "Read by Story #250 parser." in merged
+        assert "Freshly rendered body." in merged
+        assert "scope-sequence-order" in preserved["prefix"]
+
+    def test_preserve_outside_zone_is_idempotent(self):
+        """Running the merge twice doesn't duplicate the prefix."""
+        from scripts import create_issues
+
+        existing = "<!-- marker -->\n\n# Project Scope: Test\n\nA\n"
+        new = "# Project Scope: Test\n\nB\n"
+        once, _ = create_issues._preserve_outside_template_zone(existing, new)
+        twice, _ = create_issues._preserve_outside_template_zone(once, once)
+        assert once.count("<!-- marker -->") == 1
+        assert twice.count("<!-- marker -->") == 1
+
+    def test_preserve_outside_zone_keeps_trailing_signature(self):
+        """Content after the `_Created: ..._` footer survives refresh."""
+        from scripts import create_issues
+
+        existing = (
+            "# Project Scope: Test\n\n"
+            "Body.\n\n"
+            "_Created: 2026-01-01 | Owner: Someone_\n\n"
+            "---\n\n"
+            "_Operator note: this scope tracks Q1 commitment._\n"
+        )
+        new = (
+            "# Project Scope: Test\n\n"
+            "Body refreshed.\n\n"
+            "_Created: 2026-04-21 | Owner: TBD_\n"
+        )
+        merged, preserved = create_issues._preserve_outside_template_zone(existing, new)
+        assert "Operator note: this scope tracks Q1 commitment." in merged
+        assert "_Created: 2026-04-21" in merged
+        assert "Operator note" in preserved["suffix"]
+
+    def test_preserve_outside_zone_no_op_when_no_outside_content(self):
+        """When the existing body has no prefix/suffix, the merge is a no-op."""
+        from scripts import create_issues
+
+        existing = "# Project Scope: Test\n\nBody.\n"
+        new = "# Project Scope: Test\n\nNew body.\n"
+        merged, preserved = create_issues._preserve_outside_template_zone(existing, new)
+        assert merged == new
+        assert preserved["prefix"] == ""
+        assert preserved["suffix"] == ""
+
     def test_unified_diff_snippet_truncates_long_diffs(self):
         """Diffs longer than max_lines are capped with a truncation marker."""
         from scripts import create_issues


### PR DESCRIPTION
## Summary

Live dry-run of Stage 2 refresh on a real scope (`kdtix-open/agent-project-queue#182`) revealed that the existing body has a 5-line operator-authored prefix:

```
<!-- scope-sequence-order: 1 -->

> **Sequence Order: 1** — operator-declared ship-order within the multi-scope
>  backlog.  Lower numbers ship first.  Read by the `scopeSequenceOrder` parser
>  (Story #250) and consumed by the scope-aware `selectNextIssueForAssignment`
>  sort (Story #251)...
```

This is production tooling metadata, not part of the plan file. Running `refresh --apply` would STRIP it, breaking Stories #250/#251.

## Fix

`_preserve_outside_template_zone(existing, new)`:
- Extracts prefix = everything before the first `# <Level>: <Title>` heading
- Extracts suffix = everything after the last `_Created: ... | Owner: ..._` footer
- Prepends/appends them to the re-rendered body, but idempotent (re-runs don't duplicate)

Called inside `refresh_backlog` before the body-equality compare, so the `would-update` / `unchanged` decisions reflect the merged body. The report records `preserved.prefix_lines` and `preserved.suffix_lines` per issue.

## Test plan

- [x] 4 new regression tests (HTML comment prefix, trailing signature suffix, idempotent merge, no-op when no outside content)
- [x] Full suite 342/342 passing, 83.86% coverage
- [x] ruff + ruff-format clean
- [ ] Post-merge: re-run `refresh --dry-run --scope-issue 182` and confirm the 5-line sequence-order prefix appears UNCHANGED (no `- <!-- scope-sequence-order` lines in the diff)

## Why this is urgent

The operator's primary goal is to refresh existing Scopes (#182, #157, #70, #114) without losing operator-authored content. Without this PR, `--apply` is unsafe because any hand-added tooling markers get clobbered. With this PR, `--apply` becomes safe to run for the FR #34 operator workflow.

Refs #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)