### PR TITLE
feat: Mermaid diagram support at per-level template hooks (FR #40)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -256,6 +256,66 @@ task). Each subsection heading can use any markdown depth (`##` through
 Subsections are OPTIONAL — when absent, the original template placeholder remains
 and the P0-4 scanner flags it. This lets you adopt the schema one plan at a time.
 
+### Mermaid diagram support (FR #40)
+
+Any item may attach one or more Mermaid diagrams via diagram-specific subsection
+headings. Diagrams are rendered into a conventional hook section — GitHub
+renders them natively (no extra tooling required). Validation catches invalid
+Mermaid syntax before ship as a new **P0-5** compliance rule.
+
+**Recognized diagram subsection headings** (case-insensitive):
+
+| Heading | Canonical key | Default type |
+|---|---|---|
+| Architecture Diagram, Architecture, C4 Context, C4 Container, C4 Component | `architecture_diagram` | `C4Context` |
+| Sequence Diagram, Sequence | `sequence_diagram` | `sequenceDiagram` |
+| State Diagram, State Machine | `state_diagram` | `stateDiagram-v2` |
+| Flowchart, Flow Diagram | `flowchart` | `flowchart` |
+| ER Diagram, Entity Relationship Diagram, ERD | `er_diagram` | `erDiagram` |
+| Requirement Diagram, Requirements Diagram | `requirement_diagram` | `requirementDiagram` |
+| Class Diagram | `class_diagram` | `classDiagram` |
+| Diagram (generic) | `diagram` | inferred from block directive |
+
+**Per-level recommendations** (guidance, not enforcement):
+
+| Level | Rendered section | Best-fit diagram types |
+|---|---|---|
+| Scope | `## Architecture & Diagrams` | requirementDiagram, C4Context |
+| Initiative | `## Architecture & Diagrams` | C4Container, architecture-beta, erDiagram |
+| Epic | `## Architecture & Diagrams` | C4Component, flowchart, stateDiagram-v2 |
+| Story | `## Workflow & Diagrams` | sequenceDiagram, stateDiagram-v2, flowchart |
+| Task | (no hook) | usually too tactical; add manually if needed |
+
+**Authoring example** (Story with both state + sequence diagrams):
+
+````markdown
+### Story: Bridge session auth + recovery
+
+#### State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Running : dispatch
+    Running --> Succeeded : ok
+    Running --> Failed : error
+    Failed --> Idle : restart
+```
+
+#### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    Orchestrator->>Bridge: POST /work
+    Bridge->>Provider: run(prompt)
+    Provider-->>Bridge: result
+    Bridge-->>Orchestrator: 200 OK
+```
+````
+
+Backward compatibility: plans without diagram subsections render identically to
+pre-FR-#40 bodies (the diagram hook section is elided cleanly).
+
 ## Design Decisions
 
 See [design-decisions.md](https://github.com/kdtix-open/skill-plan-to-project/blob/main/references/design-decisions.md) for the full

--- a/assets/template-epic.md
+++ b/assets/template-epic.md
@@ -18,6 +18,8 @@
 
 [What becomes possible after this epic ships — 1-2 sentences]
 
+[DIAGRAMS_HOOK_EPIC]
+
 ### Success Criteria
 
 - [ ] [CRITERION 1]

--- a/assets/template-initiative.md
+++ b/assets/template-initiative.md
@@ -22,6 +22,8 @@
 
 ---
 
+[DIAGRAMS_HOOK_INITIATIVE]
+
 ### Success Criteria
 
 - [ ] [CRITERION 1]

--- a/assets/template-scope.md
+++ b/assets/template-scope.md
@@ -12,6 +12,8 @@
 
 ---
 
+[DIAGRAMS_HOOK_SCOPE]
+
 ## Business Problem & Current State
 
 [Describe the problem being solved and why the current approach is insufficient]

--- a/assets/template-story.md
+++ b/assets/template-story.md
@@ -21,6 +21,8 @@ So that [OUTCOME].
 
 [Why this story is needed and what breaks without it — 2-3 sentences]
 
+[DIAGRAMS_HOOK_STORY]
+
 ### Assumptions
 
 - **Roles**: [WHO uses the output of this story]

--- a/references/plan-format.md
+++ b/references/plan-format.md
@@ -201,3 +201,85 @@ Teams can onboard a new provider in under one day instead of one week.
 Plans without `####` subsections continue to render exactly as they did before
 — the skill falls back to using the item's raw body as the primary narrative
 field. You can adopt the subsection schema on a single plan at a time.
+
+## Mermaid Diagrams (FR #40)
+
+Any item may attach one or more Mermaid diagrams via diagram-specific
+subsection headings. Each diagram goes in its own `#### <Type> Diagram`
+subsection containing a fenced `\`\`\`mermaid` block.
+
+### Recognized diagram subsection headings
+
+- `Architecture Diagram`, `Architecture`, `C4 Context`, `C4 Container`, `C4 Component`
+- `Sequence Diagram`, `Sequence`
+- `State Diagram`, `State Machine`
+- `Flowchart`, `Flow Diagram`
+- `ER Diagram`, `Entity Relationship Diagram`, `ERD`
+- `Requirement Diagram`, `Requirements Diagram`
+- `Class Diagram`
+- `Diagram` (generic — type inferred from the block's first directive)
+
+### Per-level diagram recommendations
+
+| Level | Where it pays off most | Best-fit types |
+|---|---|---|
+| **Project Scope** | "What do we deliver + to whom" | `requirementDiagram`, `C4Context` |
+| **Initiative** | "How does this system fit together" | `C4Container`, `architecture-beta`, `erDiagram` |
+| **Epic** | "What are the pieces + how do they interact" | `C4Component`, `flowchart`, `stateDiagram-v2` |
+| **User Story** | "Exact workflow I'll implement" | `sequenceDiagram`, `stateDiagram-v2`, `flowchart` |
+| **Task** | Usually too tactical | Occasional `classDiagram` or `flowchart` |
+
+Operators may use any diagram type at any level — the table is heuristic.
+
+### Where diagrams render
+
+- Scope / Initiative / Epic: rendered into a `## Architecture & Diagrams` section
+- User Story: rendered into a `## Workflow & Diagrams` section
+- Task: no default hook — add your own section if needed
+
+### Validation
+
+Each `\`\`\`mermaid` block's first non-blank, non-comment line must start with
+a recognized directive (`flowchart`, `sequenceDiagram`, `classDiagram`,
+`stateDiagram-v2`, `erDiagram`, `C4Context`, `C4Container`, `C4Component`,
+`requirementDiagram`, `architecture-beta`, etc.). Blocks with unrecognized
+first lines are flagged by the **P0-5** compliance rule.
+
+### Example (User Story with both state + sequence diagrams)
+
+````markdown
+### Story: Bridge session auth + recovery
+
+Priority: P1
+Size: M
+
+#### TL;DR
+
+Bridge maintains a session state machine with auto-recovery on auth errors.
+
+#### State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Running : dispatch
+    Running --> Succeeded : ok
+    Running --> Failed : error
+    Failed --> Idle : restart
+```
+
+#### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    Orchestrator->>Bridge: POST /work
+    Bridge->>Provider: run(prompt)
+    Provider-->>Bridge: result
+    Bridge-->>Orchestrator: 200 OK
+```
+````
+
+### Multiple diagrams per item
+
+When an item has more than one diagram, each diagram gets a `### <Type>`
+sub-heading in the rendered section so readers can navigate between them.

--- a/scripts/compliance_check.py
+++ b/scripts/compliance_check.py
@@ -69,6 +69,80 @@ DONE_WHEN_RE = re.compile(r"I Know I Am Done When", re.IGNORECASE)
 # empty brackets + checkbox markers without requiring special cases.
 PLACEHOLDER_RE = re.compile(r"\[[A-Z][A-Z0-9 _,/\-\[\]—\.]+\]")
 
+# P0-5 (FR #40): Mermaid block validation.  A ```mermaid fenced block is
+# considered valid when its first non-blank, non-comment (`%%`) line starts
+# with one of the recognized directive tokens.  Catches the most common
+# authoring mistake — operator pastes prose into a ```mermaid block — without
+# pulling in a full Mermaid parser dependency.  For stricter validation
+# operators can run `validate_and_render_mermaid_diagram` (MCP tool) or the
+# Mermaid CLI (`mmdc`) out-of-band.
+_MERMAID_FENCE_RE = re.compile(
+    r"```\s*mermaid\s*\n(?P<body>.*?)\n```",
+    re.DOTALL | re.IGNORECASE,
+)
+_VALID_MERMAID_DIRECTIVES = (
+    "flowchart",
+    "graph",
+    "sequenceDiagram",
+    "classDiagram",
+    "stateDiagram-v2",
+    "stateDiagram",
+    "erDiagram",
+    "C4Context",
+    "C4Container",
+    "C4Component",
+    "C4Dynamic",
+    "C4Deployment",
+    "requirementDiagram",
+    "architecture-beta",
+    "journey",
+    "gantt",
+    "pie",
+    "mindmap",
+    "gitGraph",
+    "timeline",
+    "sankey-beta",
+    "quadrantChart",
+    "xychart-beta",
+    "block-beta",
+    "packet-beta",
+    "kanban",
+    "radar",
+)
+
+
+def _find_invalid_mermaid_blocks(body: str) -> list[str]:
+    """Return excerpts of invalid mermaid blocks in `body`.
+
+    A block is invalid when its first non-blank, non-comment line does NOT
+    start with a recognized directive.  Returns the offending first line
+    (trimmed to 60 chars) so the operator can locate the block.
+    """
+    invalid: list[str] = []
+    for m in _MERMAID_FENCE_RE.finditer(body):
+        source = m.group("body")
+        first_meaningful_line = ""
+        for raw in source.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("%%"):
+                continue
+            first_meaningful_line = line
+            break
+        if not first_meaningful_line:
+            invalid.append("(empty mermaid block)")
+            continue
+        first_token = first_meaningful_line.split()[0]
+        # Directives match case-insensitively (Mermaid accepts both
+        # `flowchart LR` and `FlowChart LR`).
+        valid = any(first_token.lower() == d.lower() for d in _VALID_MERMAID_DIRECTIVES)
+        if not valid:
+            excerpt = first_meaningful_line[:60]
+            if len(first_meaningful_line) > 60:
+                excerpt += "..."
+            invalid.append(excerpt)
+    return invalid
+
+
 # Additional placeholder patterns the templates use that don't match the
 # all-caps rule above (e.g. "[Describe the problem ...]", "[1-sentence
 # summary...]", "[Why this initiative exists...]").  These all start with a
@@ -157,6 +231,30 @@ def check_issue(
                 ),
                 "fixed": False,
                 "placeholders": sorted(placeholder_matches),
+            }
+        )
+
+    # P0-5 (FR #40): Invalid Mermaid blocks
+    # Any ```mermaid fenced block whose first non-blank/comment line is NOT
+    # a recognized diagram directive is flagged.  Catches "operator pasted
+    # prose instead of mermaid" + typos like "sequencDiagram".
+    invalid_mermaid = _find_invalid_mermaid_blocks(body)
+    if invalid_mermaid:
+        gaps.append(
+            {
+                "severity": "P0",
+                "rule": "P0-5",
+                "description": (
+                    f"{len(invalid_mermaid)} invalid Mermaid block(s): "
+                    f"{', '.join(invalid_mermaid[:3])}"
+                    + (
+                        f" (+ {len(invalid_mermaid) - 3} more)"
+                        if len(invalid_mermaid) > 3
+                        else ""
+                    )
+                ),
+                "fixed": False,
+                "invalid_mermaid": invalid_mermaid,
             }
         )
 
@@ -308,13 +406,17 @@ def run_compliance_check(
         # Separate P0-4 (placeholder) gaps from auto-fixable P0 gaps.
         # autofix_body only knows about P0-1/P0-2/P0-3 remediations;
         # placeholders are operator/parser work per FR #34 Stage 2+.
-        autofixable_p0 = [g for g in gaps if g["severity"] == "P0" and g["rule"] != "P0-4"]
+        autofixable_p0 = [
+            g for g in gaps if g["severity"] == "P0" and g["rule"] != "P0-4"
+        ]
         placeholder_p0 = [g for g in gaps if g["rule"] == "P0-4"]
 
         if autofixable_p0:
             fixed_body = autofix_body(body, autofixable_p0)
             update_issue_body(repo, number, fixed_body)
-            report["summary"]["p0_fixed"] += sum(1 for g in autofixable_p0 if g["fixed"])
+            report["summary"]["p0_fixed"] += sum(
+                1 for g in autofixable_p0 if g["fixed"]
+            )
 
         report["summary"]["p0_placeholders"] += len(placeholder_p0)
         report["summary"]["p1_gaps"] += sum(1 for g in gaps if g["severity"] == "P1")

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -201,6 +201,49 @@ def _extract_blocking(text: str) -> list[str]:
 
 # Per-level canonical subsection keys and the heading aliases that match
 # them.  Aliases are compared case-insensitively + whitespace-normalized.
+#
+# Diagram subsection keys (FR #40) are included at every level — each maps
+# to a canonical Mermaid diagram type.  The parser extracts the fenced
+# `mermaid` block + aggregates all diagrams into the `diagrams` list on
+# the subsection dict (see `_normalize_subsection`).
+_DIAGRAM_SUBSECTION_ALIASES: dict[str, list[str]] = {
+    "architecture_diagram": [
+        "architecture diagram",
+        "architecture",
+        "c4 diagram",
+        "c4 context diagram",
+        "c4 container diagram",
+        "c4 component diagram",
+        "c4 context",
+        "c4 container",
+        "c4 component",
+        "c4",
+    ],
+    "sequence_diagram": ["sequence diagram", "sequence"],
+    "state_diagram": ["state diagram", "state machine"],
+    "flowchart": ["flowchart", "flow chart", "flow diagram"],
+    "er_diagram": [
+        "er diagram",
+        "entity relationship diagram",
+        "entity-relationship diagram",
+        "entity relationship",
+        "entity-relationship",
+        "erd",
+    ],
+    "requirement_diagram": [
+        "requirement diagram",
+        "requirements diagram",
+    ],
+    "class_diagram": ["class diagram"],
+    "diagram": ["diagram"],
+}
+
+
+def _level_diagram_aliases() -> dict[str, list[str]]:
+    """Return a shallow copy of the diagram alias map for merging per-level."""
+    return {k: list(v) for k, v in _DIAGRAM_SUBSECTION_ALIASES.items()}
+
+
 SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
     "scope": {
         "vision": ["vision", "project vision"],
@@ -225,6 +268,7 @@ SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
             "done when",
             "definition of done",
         ],
+        **_level_diagram_aliases(),
     },
     "initiative": {
         "objective": ["objective"],
@@ -240,6 +284,7 @@ SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
             "done when",
             "definition of done",
         ],
+        **_level_diagram_aliases(),
     },
     "epic": {
         "objective": ["objective"],
@@ -260,6 +305,7 @@ SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
             "security",
             "compliance",
         ],
+        **_level_diagram_aliases(),
     },
     "story": {
         "user_story": ["user story"],
@@ -282,6 +328,7 @@ SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
             "compliance",
         ],
         "subtasks_needed": ["subtasks needed", "subtasks"],
+        **_level_diagram_aliases(),
     },
     "task": {
         "summary": ["summary"],
@@ -297,8 +344,45 @@ SUBSECTION_HEADINGS: dict[str, dict[str, list[str]]] = {
             "security",
             "compliance",
         ],
+        **_level_diagram_aliases(),
     },
 }
+
+# Set of canonical diagram keys — used by the parser + renderer to
+# recognize diagram-type subsections across all levels.
+_DIAGRAM_SUBSECTION_KEYS = set(_DIAGRAM_SUBSECTION_ALIASES.keys())
+
+# Mermaid diagram type directives (first line of a mermaid block).  Used
+# by `_infer_mermaid_type` + the validator in `compliance_check.py`.
+_MERMAID_TYPE_DIRECTIVES: tuple[str, ...] = (
+    "flowchart",
+    "graph",  # legacy flowchart alias
+    "sequenceDiagram",
+    "classDiagram",
+    "stateDiagram-v2",
+    "stateDiagram",
+    "erDiagram",
+    "C4Context",
+    "C4Container",
+    "C4Component",
+    "C4Dynamic",
+    "C4Deployment",
+    "requirementDiagram",
+    "architecture-beta",
+    "journey",
+    "gantt",
+    "pie",
+    "mindmap",
+    "gitGraph",
+    "timeline",
+    "sankey-beta",
+    "quadrantChart",
+    "xychart-beta",
+    "block-beta",
+    "packet-beta",
+    "kanban",
+    "radar",
+)
 
 # Subsections parsed as a flat list of bullets (vs. free-form paragraphs).
 _BULLET_SUBSECTIONS = {
@@ -361,7 +445,19 @@ def _parse_subsections(body: str, level: str) -> dict[str, Any]:
     def _flush_current() -> None:
         nonlocal current_key, current_lines
         if current_key is not None:
-            result[current_key] = _normalize_subsection(current_key, current_lines)
+            normalized = _normalize_subsection(current_key, current_lines)
+            # FR #40: diagrams aggregate into a single list so an item
+            # can carry N diagrams across multiple subsection headings
+            # (e.g. `#### Sequence Diagram` + `#### State Diagram` in one
+            # Story).
+            if current_key in _DIAGRAM_SUBSECTION_KEYS and normalized:
+                diagrams_list = result.setdefault("diagrams", [])
+                if isinstance(normalized, list):
+                    diagrams_list.extend(normalized)
+                else:
+                    diagrams_list.append(normalized)
+            else:
+                result[current_key] = normalized
         current_key = None
         current_lines = []
 
@@ -399,6 +495,9 @@ def _normalize_subsection(key: str, lines: list[str]) -> Any:
     if not text:
         return "" if key not in _BULLET_SUBSECTIONS else []
 
+    if key in _DIAGRAM_SUBSECTION_KEYS:
+        return _parse_diagram_blocks(text, key_hint=key)
+
     if key in _NESTED_BULLET_SUBSECTIONS:
         return _parse_nested_bullets(text, _NESTED_BULLET_SUBSECTIONS[key])
 
@@ -407,6 +506,75 @@ def _normalize_subsection(key: str, lines: list[str]) -> Any:
 
     # Default: paragraph (preserves original formatting + any inline markdown)
     return text
+
+
+_MERMAID_FENCE_RE = re.compile(
+    r"```\s*mermaid\s*\n(?P<body>.*?)\n```",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _infer_mermaid_type(mermaid_source: str) -> str | None:
+    """Return the recognized directive (e.g. 'sequenceDiagram') or None.
+
+    Inspects the first non-blank, non-comment line of a mermaid block.
+    Comments in mermaid start with `%%`.
+    """
+    for raw in mermaid_source.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("%%"):
+            continue
+        first_token = line.split()[0] if line else ""
+        # Match directives case-insensitively.  Mermaid accepts
+        # `flowchart LR`, `sequenceDiagram`, etc.  Legacy `graph TD`
+        # is normalized to "flowchart" downstream.
+        for directive in _MERMAID_TYPE_DIRECTIVES:
+            if first_token.lower() == directive.lower():
+                return directive
+        return None
+    return None
+
+
+def _parse_diagram_blocks(text: str, key_hint: str) -> list[dict[str, str]]:
+    """Extract fenced ```mermaid blocks from subsection content.
+
+    Returns a list of `{type, source}` dicts.  `type` comes from the
+    mermaid block's first directive if recognizable; otherwise falls back
+    to a guess based on `key_hint` (the subsection heading that contained
+    the block); otherwise is "unknown".
+
+    If the subsection contains NO fenced mermaid block, fall back to
+    treating the whole text as the source (gives operators a path to
+    paste mermaid without the fences, at the cost of looser validation).
+    """
+    matches = list(_MERMAID_FENCE_RE.finditer(text))
+    diagrams: list[dict[str, str]] = []
+    for m in matches:
+        source = m.group("body").strip()
+        if not source:
+            continue
+        inferred = _infer_mermaid_type(source)
+        # Map the key hint to a default directive when the block has no
+        # clear first directive (e.g. operator wrote only the body).
+        key_type_map = {
+            "architecture_diagram": "C4Context",
+            "sequence_diagram": "sequenceDiagram",
+            "state_diagram": "stateDiagram-v2",
+            "flowchart": "flowchart",
+            "er_diagram": "erDiagram",
+            "requirement_diagram": "requirementDiagram",
+            "class_diagram": "classDiagram",
+        }
+        diagram_type = inferred or key_type_map.get(key_hint, "unknown")
+        diagrams.append({"type": diagram_type, "source": source})
+    if diagrams:
+        return diagrams
+
+    # Fallback: operator wrote mermaid-looking content without fences.
+    # Accept it if the first token is a recognized directive.
+    if _infer_mermaid_type(text):
+        return [{"type": _infer_mermaid_type(text) or "unknown", "source": text}]
+    return []
 
 
 def _parse_bullets(text: str) -> list[str]:
@@ -814,6 +982,12 @@ def _render_template(template_text: str, item: dict[str, Any], level: str) -> st
     if filler is not None:
         rendered = filler(rendered, subs)
 
+    # FR #40: fill the diagram hook after section fillers so diagrams
+    # appear in their dedicated template slot (not inside any other
+    # section's content).  No-op for task (template has no diagram hook
+    # by default) + for issues with no diagrams in the plan.
+    rendered = _fill_diagrams_hook(rendered, subs, level)
+
     # Inject parent reference for levels that have one
     if parent and level in ("epic", "story", "task"):
         if "> **Parent" not in rendered:
@@ -853,6 +1027,94 @@ def _replace_block(rendered: str, old_block: str, new_block: str) -> str:
     if old_block in rendered:
         return rendered.replace(old_block, new_block, 1)
     return rendered
+
+
+def _render_diagrams_block(diagrams: list[dict[str, str]], section_title: str) -> str:
+    r"""Render a list of {type, source} diagrams as a Markdown section.
+
+    FR #40: produces a ``## <section_title>\n\n```mermaid\n...\n``` ``
+    block per diagram, separated by blank lines.  Returns empty string
+    when `diagrams` is empty so the template hook can be cleanly elided.
+    """
+    if not diagrams:
+        return ""
+    blocks: list[str] = [f"## {section_title}\n"]
+    for d in diagrams:
+        diagram_type = d.get("type", "unknown")
+        source = d.get("source", "").rstrip()
+        if not source:
+            continue
+        label = (
+            f"### {_humanize_diagram_type(diagram_type)}" if len(diagrams) > 1 else ""
+        )
+        if label:
+            blocks.append(label + "\n")
+        blocks.append(f"```mermaid\n{source}\n```\n")
+    return "\n".join(blocks).rstrip() + "\n\n---\n"
+
+
+def _humanize_diagram_type(diagram_type: str) -> str:
+    """Turn a Mermaid directive like 'sequenceDiagram' into 'Sequence Diagram'."""
+    translations = {
+        "flowchart": "Flowchart",
+        "graph": "Flowchart",
+        "sequenceDiagram": "Sequence Diagram",
+        "classDiagram": "Class Diagram",
+        "stateDiagram": "State Diagram",
+        "stateDiagram-v2": "State Diagram",
+        "erDiagram": "ER Diagram",
+        "C4Context": "C4 Context Diagram",
+        "C4Container": "C4 Container Diagram",
+        "C4Component": "C4 Component Diagram",
+        "C4Dynamic": "C4 Dynamic Diagram",
+        "C4Deployment": "C4 Deployment Diagram",
+        "requirementDiagram": "Requirement Diagram",
+        "architecture-beta": "Architecture Diagram",
+        "journey": "User Journey",
+        "gantt": "Gantt Chart",
+        "pie": "Pie Chart",
+        "mindmap": "Mindmap",
+        "gitGraph": "Git Graph",
+        "timeline": "Timeline",
+    }
+    return translations.get(diagram_type, diagram_type)
+
+
+def _fill_diagrams_hook(rendered: str, subs: dict[str, Any], level: str) -> str:
+    """Replace the level's `[DIAGRAMS_HOOK_*]` placeholder with rendered diagrams.
+
+    The title of the generated section depends on level:
+    - scope / initiative / epic → "Architecture & Diagrams"
+    - story → "Workflow & Diagrams"
+    - task → no diagram hook in template by default
+    """
+    hook_by_level = {
+        "scope": ("[DIAGRAMS_HOOK_SCOPE]", "Architecture & Diagrams"),
+        "initiative": (
+            "[DIAGRAMS_HOOK_INITIATIVE]",
+            "Architecture & Diagrams",
+        ),
+        "epic": ("[DIAGRAMS_HOOK_EPIC]", "Architecture & Diagrams"),
+        "story": ("[DIAGRAMS_HOOK_STORY]", "Workflow & Diagrams"),
+    }
+    if level not in hook_by_level:
+        return rendered
+    placeholder, section_title = hook_by_level[level]
+    if placeholder not in rendered:
+        return rendered
+    diagrams = subs.get("diagrams") or []
+    block = _render_diagrams_block(diagrams, section_title)
+    # When no diagrams, drop the whole placeholder line including trailing
+    # newlines so the template doesn't leave an empty gap.
+    if not block:
+        # Strip the placeholder line and any consecutive blank lines after it.
+        rendered = re.sub(
+            r"\n?\[DIAGRAMS_HOOK_[A-Z]+\]\n?\n?",
+            "\n",
+            rendered,
+        )
+        return rendered
+    return rendered.replace(placeholder, block.rstrip())
 
 
 def _moscow_table_rows(moscow: dict[str, list[str]]) -> str:

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -2307,3 +2307,247 @@ class TestEndToEndPlanRender:
             f"Unexpected placeholder gaps after full render: "
             f"{[g.get('placeholders') for g in p0_4]}"
         )
+
+
+# ===========================================================================
+# FR #40: Mermaid diagram subsections
+# ===========================================================================
+
+
+class TestMermaidDiagramParser:
+    def test_parses_single_sequence_diagram(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Sequence Diagram\n\n"
+            "```mermaid\n"
+            "sequenceDiagram\n"
+            "    Alice->>Bob: Hi\n"
+            "```\n"
+        )
+        subs = create_issues._parse_subsections(body, "story")
+        assert "diagrams" in subs
+        assert len(subs["diagrams"]) == 1
+        d = subs["diagrams"][0]
+        assert d["type"] == "sequenceDiagram"
+        assert "Alice->>Bob: Hi" in d["source"]
+
+    def test_parses_multiple_diagram_subsections(self):
+        """Two subsection headings → two diagrams in the list."""
+        from scripts import create_issues
+
+        body = (
+            "#### Sequence Diagram\n\n"
+            "```mermaid\n"
+            "sequenceDiagram\n    A->>B: x\n"
+            "```\n\n"
+            "#### State Diagram\n\n"
+            "```mermaid\n"
+            "stateDiagram-v2\n    [*] --> Idle\n"
+            "```\n"
+        )
+        subs = create_issues._parse_subsections(body, "story")
+        assert len(subs["diagrams"]) == 2
+        types = [d["type"] for d in subs["diagrams"]]
+        assert "sequenceDiagram" in types
+        assert "stateDiagram-v2" in types
+
+    def test_infers_type_from_block_when_subsection_is_generic(self):
+        """`#### Diagram` (generic key) gets type from the block's directive."""
+        from scripts import create_issues
+
+        body = (
+            "#### Diagram\n\n"
+            "```mermaid\n"
+            "erDiagram\n"
+            "    USER ||--o{ ORDER : places\n"
+            "```\n"
+        )
+        subs = create_issues._parse_subsections(body, "initiative")
+        assert subs["diagrams"][0]["type"] == "erDiagram"
+
+    def test_unfenced_mermaid_source_accepted_if_has_directive(self):
+        """If operator forgets fences but writes a valid directive,
+        the parser still captures the content."""
+        from scripts import create_issues
+
+        body = "#### Flowchart\n\n" "flowchart LR\n    A-->B\n    B-->C\n"
+        subs = create_issues._parse_subsections(body, "epic")
+        assert len(subs["diagrams"]) == 1
+        assert subs["diagrams"][0]["type"] == "flowchart"
+
+    def test_diagram_subsection_recognized_at_every_level(self):
+        """Every level accepts diagram subsection aliases."""
+        from scripts import create_issues
+
+        body_template = (
+            "#### Sequence Diagram\n\n"
+            "```mermaid\nsequenceDiagram\n    A->>B: x\n```\n"
+        )
+        for level in ("scope", "initiative", "epic", "story", "task"):
+            subs = create_issues._parse_subsections(body_template, level)
+            assert subs.get("diagrams"), f"Level {level} missed diagram"
+
+
+class TestMermaidDiagramRenderer:
+    def _scope_item_with_body(self, body: str) -> dict:
+        from scripts import create_issues
+
+        return {
+            "title": "Test scope",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "subsections": create_issues._parse_subsections(body, "scope"),
+        }
+
+    def test_scope_renders_architecture_diagrams_section(self):
+        from scripts import create_issues
+
+        item = self._scope_item_with_body(
+            "#### Architecture Diagram\n\n"
+            "```mermaid\n"
+            "C4Context\n    title System\n    Person(u, 'User')\n"
+            "```\n"
+        )
+        body = create_issues.generate_body(item, "scope")
+        assert "## Architecture & Diagrams" in body
+        assert "C4Context" in body
+        assert "```mermaid" in body
+
+    def test_story_renders_workflow_and_diagrams_section(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Sequence Diagram\n\n"
+            "```mermaid\nsequenceDiagram\n    A->>B: x\n```\n"
+        )
+        item = {
+            "title": "Test",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "parent_ref": "Test epic",
+            "subsections": create_issues._parse_subsections(body, "story"),
+        }
+        rendered = create_issues.generate_body(item, "story")
+        assert "## Workflow & Diagrams" in rendered
+        assert "sequenceDiagram" in rendered
+
+    def test_no_diagrams_elides_hook_section(self):
+        """When the plan has no diagrams, the template hook is removed
+        (no empty 'Architecture & Diagrams' section)."""
+        from scripts import create_issues
+
+        item = self._scope_item_with_body("Just a Vision paragraph.")
+        body = create_issues.generate_body(item, "scope")
+        assert "[DIAGRAMS_HOOK_SCOPE]" not in body
+        assert "## Architecture & Diagrams" not in body
+
+    def test_multiple_diagrams_get_sub_headings(self):
+        from scripts import create_issues
+
+        body = (
+            "#### Sequence Diagram\n\n"
+            "```mermaid\nsequenceDiagram\n    A->>B: 1\n```\n\n"
+            "#### State Diagram\n\n"
+            "```mermaid\nstateDiagram-v2\n    [*] --> Idle\n```\n"
+        )
+        item = {
+            "title": "Test",
+            "description": body,
+            "priority": "P1",
+            "size": "M",
+            "parent_ref": "Test epic",
+            "subsections": create_issues._parse_subsections(body, "story"),
+        }
+        rendered = create_issues.generate_body(item, "story")
+        # Both diagrams should render with their type labels
+        assert "### Sequence Diagram" in rendered
+        assert "### State Diagram" in rendered
+        assert "sequenceDiagram" in rendered
+        assert "stateDiagram-v2" in rendered
+
+    def test_task_level_has_no_diagram_hook_by_default(self):
+        """Task template has no [DIAGRAMS_HOOK_TASK] placeholder."""
+        from scripts import create_issues
+
+        body = "#### Flowchart\n\n" "```mermaid\nflowchart LR\n    A-->B\n```\n"
+        item = {
+            "title": "Test",
+            "description": body,
+            "priority": "P1",
+            "size": "S",
+            "parent_ref": "Test story",
+            "subsections": create_issues._parse_subsections(body, "task"),
+        }
+        rendered = create_issues.generate_body(item, "task")
+        # The diagram subsection is parsed but the task template has no
+        # conventional hook.  Operators who want a task-level diagram can
+        # add the section manually.  This asserts the render doesn't
+        # crash and doesn't pollute the body with a stray [DIAGRAMS_*]
+        # placeholder string.
+        assert "[DIAGRAMS_HOOK" not in rendered
+
+
+class TestP0_5MermaidValidation:
+    def test_valid_mermaid_block_not_flagged(self):
+        from scripts import compliance_check
+
+        body = (
+            "# Scope: Test\n\n"
+            "## Architecture & Diagrams\n\n"
+            "```mermaid\n"
+            "sequenceDiagram\n"
+            "    Alice->>Bob: Hello\n"
+            "```\n"
+        )
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        assert not [g for g in gaps if g.get("rule") == "P0-5"]
+
+    def test_invalid_mermaid_block_flagged(self):
+        from scripts import compliance_check
+
+        body = (
+            "# Scope: Test\n\n"
+            "## Architecture & Diagrams\n\n"
+            "```mermaid\n"
+            "This is not actually mermaid syntax\n"
+            "just prose someone pasted in\n"
+            "```\n"
+        )
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        p0_5 = [g for g in gaps if g.get("rule") == "P0-5"]
+        assert len(p0_5) == 1
+        assert "invalid Mermaid" in p0_5[0]["description"]
+
+    def test_empty_mermaid_block_flagged(self):
+        from scripts import compliance_check
+
+        body = "```mermaid\n\n```\n"
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        p0_5 = [g for g in gaps if g.get("rule") == "P0-5"]
+        assert len(p0_5) == 1
+
+    def test_comments_in_mermaid_block_are_skipped(self):
+        """`%%` comment lines don't count as the 'first line'."""
+        from scripts import compliance_check
+
+        body = (
+            "```mermaid\n"
+            "%% top comment\n"
+            "%% another comment\n"
+            "sequenceDiagram\n"
+            "    A->>B: x\n"
+            "```\n"
+        )
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        assert not [g for g in gaps if g.get("rule") == "P0-5"]
+
+    def test_mermaid_validation_case_insensitive(self):
+        """`FlowChart LR` (mixed case) is still recognized as valid."""
+        from scripts import compliance_check
+
+        body = "```mermaid\n" "FlowChart LR\n" "    A --> B\n" "```\n"
+        gaps = compliance_check.check_issue(1, "Test", body, "scope")
+        assert not [g for g in gaps if g.get("rule") == "P0-5"]


### PR DESCRIPTION
## Summary

Closes the Mermaid-at-preferred-depths design captured in Epic #40. Plans can now attach Mermaid diagrams to any item; the renderer injects them into a conventional section per level so Provider Workers and Reviewers have a shared architectural visual.

## What ships

**Diagram subsection schema** (all 5 levels):
- 8 canonical keys: `architecture_diagram`, `sequence_diagram`, `state_diagram`, `flowchart`, `er_diagram`, `requirement_diagram`, `class_diagram`, `diagram` (generic)
- Each accepts multiple aliases (`C4 Context`, `ERD`, `State Machine`, etc.)
- Multi-diagram aggregation: multiple subsections → one `subsections["diagrams"]` list

**Template hooks**:
- Scope / Initiative / Epic → `## Architecture & Diagrams`
- Story → `## Workflow & Diagrams`
- Task → no hook (too tactical by default; operators add manually)
- Hook is elided cleanly when no diagrams present (no empty sections)

**Parser**:
- Extracts fenced ` ```mermaid ` blocks from subsection content
- Falls back to unfenced content when the first token is a recognized directive
- `_infer_mermaid_type()` reads the first non-comment line to assign a canonical directive

**P0-5 compliance rule**: invalid Mermaid block (first non-blank/non-comment line not a recognized directive). 27 directives recognized case-insensitively — catches the "operator pasted prose" failure mode.

## Tests

15 new tests (5 parser, 5 renderer, 5 P0-5 validator). Full suite 357/357 passing, 84.31% coverage.

## Docs

- `SKILL.md`: diagram heading aliases table + per-level recommendations + authoring example
- `plan-format.md`: full `## Mermaid Diagrams` section with example, multi-diagram rendering, validation rules

## Test plan

- [x] 15 new tests for parser / renderer / validator
- [x] 357 / 357 full suite; 84.31% coverage
- [x] `ruff check` clean
- [ ] End-to-end post-merge: reinstall skill + add a diagram to a plan item + verify GitHub renders it after create

## Backward compatibility

Plans without diagram subsections render identically to pre-FR-#40 bodies. Adoption is per-item.

Refs #40 Epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)