### PR TITLE
fix(refresh): normalize markdown markers in titles for cross-source matching

### DIFF
--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -2009,6 +2009,47 @@ def _walk_existing_hierarchy(
     return results
 
 
+_LEVEL_PREFIXES_FOR_NORMALIZE = (
+    "Project Scope:",
+    "Scope:",
+    "Initiative:",
+    "Epic:",
+    "Story:",
+    "User Story:",
+    "Task:",
+)
+
+# Markdown markers we strip before comparing titles so plan-authored
+# titles with backticks / bold / italics still match GitHub-rendered
+# plain-text titles.  Stars for bold/italic, backticks for inline code.
+_TITLE_MARKDOWN_RE = re.compile(r"[`*_]+")
+
+
+def _normalize_title_for_match(title: str) -> str:
+    """Canonicalize a title for cross-source matching.
+
+    Applied symmetrically to plan-parsed titles + existing-issue titles so
+    the refresh walker can correlate them despite differences in markdown
+    formatting.  Current normalizations:
+
+    - strip leading level prefixes (`Project Scope: `, `Initiative: `, etc.)
+    - strip markdown markers: backticks (`` ` ``), bold/italic markers (`*`, `_`)
+    - collapse internal whitespace
+    - lowercase + trim
+
+    Safe for symmetric use: both sides of the comparison MUST call this
+    function for the result to match.
+    """
+    t = title.strip()
+    for prefix in _LEVEL_PREFIXES_FOR_NORMALIZE:
+        if t.lower().startswith(prefix.lower()):
+            t = t[len(prefix) :].strip()
+            break
+    t = _TITLE_MARKDOWN_RE.sub("", t)
+    t = re.sub(r"\s+", " ", t)
+    return t.lower().strip()
+
+
 def _flatten_parsed_hierarchy(hierarchy: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Flatten parse_plan() output into a {normalized_title: item} map.
 
@@ -2018,22 +2059,7 @@ def _flatten_parsed_hierarchy(hierarchy: dict[str, Any]) -> dict[str, dict[str, 
     items_by_title: dict[str, dict[str, Any]] = {}
 
     def _normalize(title: str) -> str:
-        # Strip common prefixes that may or may not be present in GH titles:
-        # "Project Scope: ", "Initiative: ", "Epic: ", "Story: ", "Task: "
-        t = title.strip()
-        for prefix in [
-            "Project Scope:",
-            "Scope:",
-            "Initiative:",
-            "Epic:",
-            "Story:",
-            "User Story:",
-            "Task:",
-        ]:
-            if t.lower().startswith(prefix.lower()):
-                t = t[len(prefix) :].strip()
-                break
-        return t.lower().strip()
+        return _normalize_title_for_match(title)
 
     def _register(item: dict[str, Any], level: str) -> None:
         norm = _normalize(item.get("title", ""))
@@ -2200,21 +2226,9 @@ def refresh_backlog(
         number = entry["number"]
         title = entry["title"]
         level = entry["level"]
-        # Normalize existing title same way
-        norm = title.strip()
-        for prefix in [
-            "Project Scope:",
-            "Scope:",
-            "Initiative:",
-            "Epic:",
-            "Story:",
-            "User Story:",
-            "Task:",
-        ]:
-            if norm.lower().startswith(prefix.lower()):
-                norm = norm[len(prefix) :].strip()
-                break
-        norm = norm.lower().strip()
+        # Normalize existing title same way as the plan's parsed titles so
+        # backticks / bold / inline-code markers don't block matching.
+        norm = _normalize_title_for_match(title)
 
         item = items_by_title.get(norm)
         per_issue_record: dict[str, Any] = {

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -900,6 +900,37 @@ class TestWalkExistingHierarchy:
 class TestRefreshMode:
     """FR #34 Stage 5: refresh existing backlog in-place without duplicates."""
 
+    def test_normalize_title_strips_markdown_markers(self):
+        """Backticks, bold, italic in plan titles must match plain-text GitHub titles."""
+        from scripts import create_issues
+
+        plan_title = (
+            "Story: Self-Heal R-10 — Bridge credential allow-list must "
+            "accept generic `GITHUB_TOKEN` / `GH_TOKEN`"
+        )
+        gh_title = (
+            "Story: Self-Heal R-10 — Bridge credential allow-list must "
+            "accept generic GITHUB_TOKEN / GH_TOKEN"
+        )
+        assert create_issues._normalize_title_for_match(
+            plan_title
+        ) == create_issues._normalize_title_for_match(gh_title)
+
+    def test_normalize_title_strips_bold_and_italics(self):
+        from scripts import create_issues
+
+        assert create_issues._normalize_title_for_match(
+            "Story: **Critical** auth fix"
+        ) == create_issues._normalize_title_for_match("Story: Critical auth fix")
+
+    def test_normalize_title_collapses_whitespace(self):
+        from scripts import create_issues
+
+        assert (
+            create_issues._normalize_title_for_match("Story:  double  space  inside")
+            == "double space inside"
+        )
+
     def test_flatten_parsed_hierarchy_normalizes_prefixes(self):
         from scripts import create_issues
 


### PR DESCRIPTION
Live refresh on kdtix-open/agent-project-queue#182 after folding R-10/R-11/R-12 into the plan found 3 still-unmatched issues because plan titles had backticks around code spans while GitHub-rendered titles are plain text.

Extract shared `_normalize_title_for_match()` used symmetrically by `_flatten_parsed_hierarchy` + the `refresh_backlog` walker loop. Strips backticks, bold/italic markers, and collapses whitespace.

3 new tests; 360/360 full suite passing, 84.32% coverage.

Refs #34 Stage 5.