### PR TITLE
feat(refresh): --skip-issue flag for excluding specific issues from --apply

### DIFF
--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -2175,6 +2175,7 @@ def refresh_backlog(
     repo: str,
     scope_issue_number: int,
     dry_run: bool = True,
+    skip_issues: set[int] | None = None,
 ) -> dict[str, Any]:
     """Patch/upgrade existing backlog issues using the current skill's
     template + parser.  Does NOT create or remove any issues.
@@ -2192,6 +2193,14 @@ def refresh_backlog(
       5. Compare to existing body; if different, emit (dry_run) or apply
          (via gh issue edit) the update.
       6. Report a summary: matched / unmatched / updated / unchanged.
+
+    Args:
+        skip_issues: optional set of issue numbers to exclude from update.
+            Issues in this set are reported as status='skipped' in the
+            per-issue report + never have their bodies re-rendered or
+            updated.  Use when dry-run review identifies specific issues
+            whose existing body should be preserved (e.g. hand-authored
+            content that the template-rendered body would degrade).
     """
     from scripts.gh_helpers import get_issue_body, update_issue_body
 
@@ -2206,9 +2215,18 @@ def refresh_backlog(
             "updated": 0,
             "unchanged": 0,
             "failed": 0,
+            "skipped": 0,
         },
         "per_issue": [],
     }
+
+    skip_set: set[int] = set(skip_issues or set())
+    if skip_set:
+        report["skip_issues"] = sorted(skip_set)
+        print(
+            f"[refresh] skip-list: {sorted(skip_set)} "
+            f"(will be reported as status='skipped')"
+        )
 
     print(
         f"[refresh] walking existing hierarchy rooted at "
@@ -2236,6 +2254,13 @@ def refresh_backlog(
             "title": title,
             "level": level,
         }
+
+        if number in skip_set:
+            per_issue_record["status"] = "skipped"
+            report["summary"]["skipped"] += 1
+            print(f"[refresh] #{number} SKIPPED (in operator skip-list)")
+            report["per_issue"].append(per_issue_record)
+            continue
 
         if not item:
             per_issue_record["status"] = "unmatched"
@@ -2315,9 +2340,10 @@ def refresh_backlog(
         report["per_issue"].append(per_issue_record)
 
     s = report["summary"]
+    skip_summary = f" / {s.get('skipped', 0)} skipped" if s.get("skipped") else ""
     print(
         f"[refresh] DONE — {s['existing_issues']} issues | "
-        f"{s['matched']} matched / {s['unmatched']} unmatched | "
+        f"{s['matched']} matched / {s['unmatched']} unmatched{skip_summary} | "
         f"{s['updated']} {'would-update' if dry_run else 'updated'} / "
         f"{s['unchanged']} unchanged / {s['failed']} failed"
     )
@@ -2326,11 +2352,13 @@ def refresh_backlog(
 
 def _cmd_refresh(args: argparse.Namespace) -> None:
     out = Path(args.output_dir) if args.output_dir else None
+    skip_issues: set[int] = set(getattr(args, "skip_issue", None) or [])
     report = refresh_backlog(
         plan_path=args.plan,
         repo=args.repo,
         scope_issue_number=args.scope_issue,
         dry_run=args.dry_run,
+        skip_issues=skip_issues or None,
     )
     if out:
         out.mkdir(parents=True, exist_ok=True)
@@ -2396,6 +2424,18 @@ def main() -> None:
     )
     p_refresh.add_argument(
         "--output-dir", default=None, help="Output directory for refresh-report.json"
+    )
+    p_refresh.add_argument(
+        "--skip-issue",
+        type=int,
+        action="append",
+        default=None,
+        help=(
+            "Issue number(s) to exclude from refresh (repeatable). "
+            "Skipped issues are reported as status='skipped' and NEVER have "
+            "their bodies re-rendered or updated. Use when dry-run review "
+            "identifies issues whose existing body should be preserved."
+        ),
     )
 
     args = parser.parse_args()

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -1011,6 +1011,67 @@ class TestRefreshMode:
         assert "issue-182-after" in diff_text
         assert "OLD BODY" in diff_text  # the removed line shows in the diff
 
+    def test_refresh_skip_issues_excludes_from_apply(self, mocker):
+        """Issues in skip_issues are reported as 'skipped', never body-fetched."""
+        from scripts import create_issues
+
+        mocker.patch(
+            "scripts.create_issues.parse_plan",
+            return_value={
+                "scope": {
+                    "title": "Project Scope: PS-X Test",
+                    "description": "desc",
+                    "priority": "P0",
+                    "size": "M",
+                },
+                "initiatives": [],
+                "epics": [],
+                "stories": [],
+                "tasks": [],
+            },
+        )
+        mocker.patch(
+            "scripts.create_issues._walk_existing_hierarchy",
+            return_value=[
+                {
+                    "number": 182,
+                    "title": "Project Scope: PS-X Test",
+                    "level": "scope",
+                    "parent_number": None,
+                },
+                {
+                    "number": 266,
+                    "title": "Story: Preserve me",
+                    "level": "story",
+                    "parent_number": 182,
+                },
+            ],
+        )
+        get_body_mock = mocker.patch(
+            "scripts.gh_helpers.get_issue_body", return_value="# Old scope body"
+        )
+        update_mock = mocker.patch("scripts.gh_helpers.update_issue_body")
+
+        report = create_issues.refresh_backlog(
+            plan_path="dummy.md",
+            repo="owner/repo",
+            scope_issue_number=182,
+            dry_run=False,
+            skip_issues={266},
+        )
+
+        # Skipped issue is reported as 'skipped' + never body-fetched
+        statuses = {i["number"]: i["status"] for i in report["per_issue"]}
+        assert statuses[266] == "skipped"
+        assert report["summary"]["skipped"] == 1
+        # get_issue_body was called for #182 but NOT #266
+        fetched_numbers = [call.args[1] for call in get_body_mock.call_args_list]
+        assert 266 not in fetched_numbers
+        # update_issue_body never called with #266
+        for call in update_mock.call_args_list:
+            args = call.args
+            assert args[1] != 266
+
     def test_preserve_outside_zone_keeps_html_comment_prefix(self):
         """Stage 2.5: HTML comment + blockquote before `# Heading` survive refresh."""
         from scripts import create_issues


### PR DESCRIPTION
Live dry-run on #182 revealed 3 Self-Heal stories whose hand-authored bodies would degrade on refresh. Adds `--skip-issue N` (repeatable) so operators can excise specific issues from --apply after reviewing the dry-run diff.

Skipped issues report status='skipped' + are never body-fetched/re-rendered. Summary gains `skipped` counter. 1 new test; 361/361 passing.

Refs #34 Stage 5.