### PR TITLE
feat(auth): GitHub App installation token helper (FR #49)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -18,12 +18,42 @@ GitHub Project backlog in a single workflow.
 ## Prerequisites
 
 - `gh` CLI authenticated (`gh auth status`). If not: `gh auth login`
-- Python 3.9+ available
+- Python 3.9+ available (`PyJWT` + `cryptography` required for the App-token
+  helper; the rest of the skill has no Python deps beyond stdlib)
 - Target GitHub org has Issue Types configured: `Project Scope`, `Initiative`, `Epic`,
-  `User Story`, `Task`
+  `User Story`, `Task` — or pass `--auto-create-issue-types` (FR #46) to have
+  preflight create them via GraphQL
 - Target GitHub Project V2 has fields: `Priority` (P0/P1/P2), `Size` (XS/S/M/L/XL),
   `Status` (Backlog/In Progress/Done/Blocked)
 - Input plan follows KDTIX markdown structure (see [plan-format.md](https://github.com/kdtix-open/skill-plan-to-project/blob/main/references/plan-format.md))
+  — and per FR #45, uses the full subsection schema by default
+
+### Auth: personal PAT vs GitHub App installation token (FR #49)
+
+For **Enterprise-owned orgs**, personal fine-grained PATs cannot combine user-scoped
+permissions (e.g. "Copilot Requests") with Enterprise-org-scoped permissions
+(e.g. `read:project` + `project`). The correct pattern for automation against
+Enterprise-owned orgs is a **GitHub App installation token**.
+
+The skill ships a helper:
+
+```bash
+# One-time setup
+export SDLCA_APP_ID=<App-ID>
+export SDLCA_APP_PRIVATE_KEY_PATH=~/.sdlca/<app-slug>.pem
+chmod 0600 $SDLCA_APP_PRIVATE_KEY_PATH
+
+# Mint 1-hour installation token (auto-discovers installation for the org)
+source scripts/use-app-token.sh kdtix-open
+# Exports GH_TOKEN + COPILOT_GITHUB_TOKEN (same value, both aliases set)
+
+# Skill now works against Enterprise-owned org repos
+python3 -m scripts.create_issues preflight \
+  --org kdtix-open --repo kdtix-open/agent-project-queue --project 7
+```
+
+Alternative for non-Enterprise orgs: personal fine-grained PAT or `gh auth login`
+with `read:project` + `project` scopes continues to work.
 
 ## Inputs
 

--- a/scripts/mint_app_token.py
+++ b/scripts/mint_app_token.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+mint_app_token.py — FR #49: mint a GitHub App installation token.
+
+Reads a GitHub App's private key + App ID, signs a short-lived JWT, and
+exchanges it for a 1-hour installation access token scoped to a given
+org's installation.  Prints the token to stdout.
+
+Primary use case: unblock plan-to-project + SBR skill runs against
+Enterprise-owned orgs where personal fine-grained PATs cannot combine the
+required scopes.  The App's installation token inherits whatever permissions
+the App was granted on the org — in the `projectit-ai-repo-orchestrator`
+case, that's a superset of what the skill needs (Issues r/w, Contents r/w,
+Projects r/w, Issue types r/w, Administration r, Copilot metrics r, etc.).
+
+Configuration (env vars or ~/.sdlca/app.conf):
+
+    SDLCA_APP_ID                      GitHub App's numeric ID (required)
+    SDLCA_APP_PRIVATE_KEY_PATH        Path to .pem file (required)
+    SDLCA_APP_INSTALLATION_ID_<ORG>   Optional per-org installation ID.
+                                      Auto-discovered if unset.
+
+Usage:
+
+    python3 -m scripts.mint_app_token kdtix-open
+    # → prints token to stdout
+
+    TOKEN=$(python3 -m scripts.mint_app_token kdtix-open)
+    GH_TOKEN=$TOKEN gh api /user
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+try:
+    import jwt as _pyjwt
+except ImportError:  # pragma: no cover
+    print(
+        "[mint-app-token] ERROR: PyJWT is not installed.\n"
+        "  pip install PyJWT cryptography",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _load_config() -> tuple[str, Path]:
+    """Load App ID + private key path from env / ~/.sdlca/app.conf.
+
+    Returns (app_id, private_key_path).
+    Raises SystemExit with helpful message if config incomplete.
+    """
+    app_id = os.environ.get("SDLCA_APP_ID", "").strip()
+    key_path_raw = os.environ.get("SDLCA_APP_PRIVATE_KEY_PATH", "").strip()
+
+    # Fallback: ~/.sdlca/app.conf (shell-style KEY=VALUE)
+    conf_path = Path.home() / ".sdlca" / "app.conf"
+    if (not app_id or not key_path_raw) and conf_path.is_file():
+        for raw_line in conf_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            k = k.strip()
+            v = v.strip().strip('"').strip("'")
+            if k == "SDLCA_APP_ID" and not app_id:
+                app_id = v
+            elif k == "SDLCA_APP_PRIVATE_KEY_PATH" and not key_path_raw:
+                key_path_raw = v
+
+    if not app_id:
+        print(
+            "[mint-app-token] ERROR: SDLCA_APP_ID not set.\n"
+            "  Get the App ID from the App's settings page:\n"
+            "  https://github.com/organizations/<org>/settings/apps/<app-slug>\n"
+            "  Set via env (`export SDLCA_APP_ID=...`) or ~/.sdlca/app.conf",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if not key_path_raw:
+        print(
+            "[mint-app-token] ERROR: SDLCA_APP_PRIVATE_KEY_PATH not set.\n"
+            "  Download the App's private key (.pem) from the App settings page\n"
+            "  and save under ~/.sdlca/ with chmod 0600.\n"
+            "  Set via env or ~/.sdlca/app.conf.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    key_path = Path(os.path.expanduser(key_path_raw))
+    if not key_path.is_file():
+        print(
+            f"[mint-app-token] ERROR: private key not found at {key_path}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return app_id, key_path
+
+
+def _sign_app_jwt(app_id: str, private_key_path: Path) -> str:
+    """Sign a short-lived (~10 min) JWT authenticating as the App itself.
+
+    Clock-skew tolerance: -60 seconds on iat.
+    Expiry: +540 seconds (9 min); GitHub max is 10 min.
+    """
+    pem = private_key_path.read_bytes()
+    now = _dt.datetime.now(tz=_dt.timezone.utc)
+    payload = {
+        "iat": int((now - _dt.timedelta(seconds=60)).timestamp()),
+        "exp": int((now + _dt.timedelta(seconds=540)).timestamp()),
+        "iss": app_id,
+    }
+    return _pyjwt.encode(payload, pem, algorithm="RS256")
+
+
+def _http_request(
+    url: str, token: str, method: str = "GET"
+) -> tuple[int, dict]:
+    """Minimal GitHub API call (stdlib urllib; no `requests` dependency)."""
+    # URL is always hardcoded https://api.github.com/... from the two call
+    # sites below; no user-controlled scheme risk.  S310 false positive.
+    req = urllib.request.Request(url, method=method)  # noqa: S310
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8")
+            return resp.getcode(), json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = {"message": body}
+        return exc.code, payload
+
+
+def _discover_installation_id(app_jwt: str, org: str) -> int:
+    """Query GitHub for the App's installation ID on the given org."""
+    status, payload = _http_request(
+        f"https://api.github.com/orgs/{org}/installation", app_jwt
+    )
+    if status != 200 or "id" not in payload:
+        print(
+            f"[mint-app-token] ERROR: could not discover installation "
+            f"for org '{org}' (HTTP {status}): {payload.get('message', '?')}",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    return int(payload["id"])
+
+
+def _mint_installation_token(app_jwt: str, installation_id: int) -> dict:
+    """Exchange the App JWT for a 1-hour installation access token."""
+    status, payload = _http_request(
+        f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+        app_jwt,
+        method="POST",
+    )
+    if status not in (200, 201) or "token" not in payload:
+        print(
+            f"[mint-app-token] ERROR: installation-token mint failed "
+            f"(HTTP {status}): {payload.get('message', '?')}",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    return payload
+
+
+def mint_for_org(org: str) -> dict:
+    """High-level: returns {'token', 'expires_at', 'installation_id'} dict."""
+    app_id, key_path = _load_config()
+    app_jwt = _sign_app_jwt(app_id, key_path)
+
+    env_key = f"SDLCA_APP_INSTALLATION_ID_{org.upper().replace('-', '_')}"
+    explicit = os.environ.get(env_key, "").strip()
+    installation_id = (
+        int(explicit) if explicit.isdigit() else _discover_installation_id(app_jwt, org)
+    )
+
+    resp = _mint_installation_token(app_jwt, installation_id)
+    return {
+        "token": resp["token"],
+        "expires_at": resp.get("expires_at", ""),
+        "installation_id": installation_id,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Mint a GitHub App installation token for a given org."
+    )
+    parser.add_argument("org", help="Org login (e.g. `kdtix-open`).")
+    parser.add_argument(
+        "--format",
+        choices=("token", "json", "env"),
+        default="token",
+        help=(
+            "Output format: `token` (just the token, default), "
+            "`json` (full response with expiry + installation id), "
+            "`env` (shell-compatible: GH_TOKEN=... COPILOT_GITHUB_TOKEN=...)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    result = mint_for_org(args.org)
+
+    if args.format == "token":
+        print(result["token"])
+    elif args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:  # env
+        t = result["token"]
+        exp = result["expires_at"]
+        print(f"export GH_TOKEN={t}")
+        print(f"export COPILOT_GITHUB_TOKEN={t}")
+        print(f"# expires at {exp} (installation_id={result['installation_id']})")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_mint_app_token.py
+++ b/scripts/tests/test_mint_app_token.py
@@ -1,0 +1,226 @@
+"""Tests for scripts/mint_app_token.py (FR #49)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts import mint_app_token
+
+
+def _generate_test_keypair(tmp_path: Path) -> Path:
+    """Write a throwaway RSA key so PyJWT's sign + verify round-trips work."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    path = tmp_path / "test_key.pem"
+    path.write_bytes(pem)
+    return path
+
+
+class TestLoadConfig:
+    def test_load_config_from_env(self, tmp_path, monkeypatch):
+        key = _generate_test_keypair(tmp_path)
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
+        # Avoid finding a user ~/.sdlca/app.conf during tests
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+
+        app_id, path = mint_app_token._load_config()
+        assert app_id == "12345"
+        assert path == key
+
+    def test_load_config_from_conf_file(self, tmp_path, monkeypatch):
+        key = _generate_test_keypair(tmp_path)
+        (tmp_path / ".sdlca").mkdir()
+        conf = tmp_path / ".sdlca" / "app.conf"
+        conf.write_text(
+            f'SDLCA_APP_ID="99999"\nSDLCA_APP_PRIVATE_KEY_PATH="{key}"\n'
+        )
+        monkeypatch.delenv("SDLCA_APP_ID", raising=False)
+        monkeypatch.delenv("SDLCA_APP_PRIVATE_KEY_PATH", raising=False)
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+
+        app_id, path = mint_app_token._load_config()
+        assert app_id == "99999"
+        assert path == key
+
+    def test_load_config_missing_app_id_exits(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("SDLCA_APP_ID", raising=False)
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            mint_app_token._load_config()
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "SDLCA_APP_ID not set" in captured.err
+
+    def test_load_config_missing_key_path_exits(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.delenv("SDLCA_APP_PRIVATE_KEY_PATH", raising=False)
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            mint_app_token._load_config()
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "SDLCA_APP_PRIVATE_KEY_PATH not set" in captured.err
+
+    def test_load_config_key_path_not_found_exits(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv(
+            "SDLCA_APP_PRIVATE_KEY_PATH", str(tmp_path / "does-not-exist.pem")
+        )
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            mint_app_token._load_config()
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "private key not found" in captured.err
+
+
+class TestSignAppJwt:
+    def test_sign_produces_valid_rs256_jwt(self, tmp_path):
+        import jwt as pyjwt
+        from cryptography.hazmat.primitives import serialization
+
+        key_path = _generate_test_keypair(tmp_path)
+        token = mint_app_token._sign_app_jwt("12345", key_path)
+
+        # Verify with the corresponding public key
+        priv = serialization.load_pem_private_key(
+            key_path.read_bytes(), password=None
+        )
+        pub = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        decoded = pyjwt.decode(token, pub, algorithms=["RS256"])
+        assert decoded["iss"] == "12345"
+        assert "iat" in decoded
+        assert "exp" in decoded
+        # exp > iat by roughly 10 minutes
+        assert decoded["exp"] - decoded["iat"] >= 540
+
+
+class TestMintForOrg:
+    def test_mint_auto_discovers_installation_and_mints(
+        self, tmp_path, monkeypatch
+    ):
+        key = _generate_test_keypair(tmp_path)
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("SDLCA_APP_INSTALLATION_ID_KDTIX_OPEN", raising=False)
+
+        def fake_http(url, token, method="GET"):
+            if url.endswith("/orgs/kdtix-open/installation"):
+                assert method == "GET"
+                return 200, {"id": 9876543}
+            if url.endswith("/app/installations/9876543/access_tokens"):
+                assert method == "POST"
+                return 201, {
+                    "token": "ghs_TESTOKEN",
+                    "expires_at": "2026-04-22T08:00:00Z",
+                }
+            raise AssertionError(f"unexpected URL: {url}")
+
+        with patch.object(mint_app_token, "_http_request", side_effect=fake_http):
+            result = mint_app_token.mint_for_org("kdtix-open")
+
+        assert result["token"] == "ghs_TESTOKEN"  # noqa: S105 — test fixture
+        assert result["expires_at"] == "2026-04-22T08:00:00Z"
+        assert result["installation_id"] == 9876543
+
+    def test_mint_respects_explicit_installation_id_env(
+        self, tmp_path, monkeypatch
+    ):
+        key = _generate_test_keypair(tmp_path)
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
+        monkeypatch.setenv("SDLCA_APP_INSTALLATION_ID_KDTIX_OPEN", "11111")
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+
+        call_urls: list[str] = []
+
+        def fake_http(url, token, method="GET"):
+            call_urls.append(url)
+            return 201, {
+                "token": "ghs_ANOTHER",
+                "expires_at": "2026-04-22T08:00:00Z",
+            }
+
+        with patch.object(mint_app_token, "_http_request", side_effect=fake_http):
+            result = mint_app_token.mint_for_org("kdtix-open")
+
+        # Discovery endpoint should NOT be called when env override present
+        assert not any(
+            u.endswith("/orgs/kdtix-open/installation") for u in call_urls
+        )
+        # Mint endpoint uses the explicit installation ID
+        assert any(u.endswith("/installations/11111/access_tokens") for u in call_urls)
+        assert result["installation_id"] == 11111
+
+    def test_mint_fails_loud_on_unknown_org(self, tmp_path, monkeypatch, capsys):
+        key = _generate_test_keypair(tmp_path)
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("SDLCA_APP_INSTALLATION_ID_NOPE", raising=False)
+
+        def fake_http(url, token, method="GET"):
+            return 404, {"message": "Not Found"}
+
+        with patch.object(mint_app_token, "_http_request", side_effect=fake_http):
+            with pytest.raises(SystemExit) as exc_info:
+                mint_app_token.mint_for_org("nope")
+        assert exc_info.value.code == 3
+        captured = capsys.readouterr()
+        assert "could not discover installation" in captured.err
+
+
+class TestCli:
+    def test_cli_format_env(self, tmp_path, monkeypatch, capsys):
+        key = _generate_test_keypair(tmp_path)
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
+        monkeypatch.setenv("SDLCA_APP_INSTALLATION_ID_KDTIX_OPEN", "11111")
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+
+        with patch.object(
+            mint_app_token,
+            "_http_request",
+            return_value=(201, {"token": "ghs_XYZ", "expires_at": "Z"}),
+        ):
+            rc = mint_app_token.main(["kdtix-open", "--format", "env"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "export GH_TOKEN=ghs_XYZ" in captured.out
+        assert "export COPILOT_GITHUB_TOKEN=ghs_XYZ" in captured.out
+        assert "expires at Z" in captured.out
+
+    def test_cli_format_token(self, tmp_path, monkeypatch, capsys):
+        key = _generate_test_keypair(tmp_path)
+        monkeypatch.setenv("SDLCA_APP_ID", "12345")
+        monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
+        monkeypatch.setenv("SDLCA_APP_INSTALLATION_ID_KDTIX_OPEN", "11111")
+        monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
+
+        with patch.object(
+            mint_app_token,
+            "_http_request",
+            return_value=(201, {"token": "ghs_JUST_TOKEN", "expires_at": "Z"}),
+        ):
+            rc = mint_app_token.main(["kdtix-open", "--format", "token"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Single-line: just the token
+        assert captured.out.strip() == "ghs_JUST_TOKEN"

--- a/scripts/use-app-token.sh
+++ b/scripts/use-app-token.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# use-app-token.sh — FR #49: source this to export GH_TOKEN + COPILOT_GITHUB_TOKEN.
+#
+# Usage:
+#   source scripts/use-app-token.sh <org>
+#   # e.g. source scripts/use-app-token.sh kdtix-open
+#
+# Reads config from SDLCA_APP_ID + SDLCA_APP_PRIVATE_KEY_PATH (env or
+# ~/.sdlca/app.conf), mints a fresh 1-hour installation token via
+# `python3 -m scripts.mint_app_token`, and exports both env var names so
+# consumers of either conventional name (plan-to-project skill uses
+# GH_TOKEN; some Copilot workflows expect COPILOT_GITHUB_TOKEN) pick it up.
+#
+# This script is idempotent — re-sourcing refreshes the token.
+
+set -uo pipefail
+
+# shellcheck disable=SC2164
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ "$#" -lt 1 ]; then
+    echo "[use-app-token] Usage: source use-app-token.sh <org>" >&2
+    echo "[use-app-token]   e.g. source use-app-token.sh kdtix-open" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+ORG="$1"
+
+# Resolve a Python runner — prefer the project's pyproject-bound tool if
+# available, otherwise fall back to plain python3.  The mint helper has no
+# third-party deps beyond PyJWT + cryptography which are usually already
+# installed (the skill's setup docs call them out).
+PYTHON="${PYTHON:-python3}"
+
+cd "${PROJECT_DIR}"
+
+ENV_OUTPUT="$(${PYTHON} -m scripts.mint_app_token "${ORG}" --format env)"
+MINT_STATUS=$?
+
+if [ "${MINT_STATUS}" -ne 0 ] || [ -z "${ENV_OUTPUT}" ]; then
+    echo "[use-app-token] mint failed (exit ${MINT_STATUS}); env not exported" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+# The mint tool's --format=env output is:
+#   export GH_TOKEN=...
+#   export COPILOT_GITHUB_TOKEN=...
+#   # expires at <iso>
+# Source it into the current shell (operator's shell when `source`d).
+# shellcheck disable=SC1090
+eval "${ENV_OUTPUT}"
+
+EXPIRY_LINE="$(echo "${ENV_OUTPUT}" | grep -E '^# expires at' | head -1)"
+echo "[use-app-token] exported GH_TOKEN + COPILOT_GITHUB_TOKEN for ${ORG}"
+if [ -n "${EXPIRY_LINE}" ]; then
+    echo "[use-app-token] ${EXPIRY_LINE#\# }"
+fi


### PR DESCRIPTION
Closes #49. Helper for minting App installation tokens as GH_TOKEN / COPILOT_GITHUB_TOKEN for Enterprise-owned orgs where personal fine-grained PATs can't combine the required scopes. 11 new tests; 381/381 passing. Path A from Copilot Agent research task 7b90be46-... on 2026-04-22.