### PR TITLE
feat(sbr): Stage 1 MVP — API + CLI + MCP Server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,16 @@ name = "plan-to-project"
 version = "0.1.0"
 description = "GitHub Copilot skill: convert a markdown plan into a GitHub Project backlog"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = [
+    "PyJWT>=2.8",
+    "cryptography>=42",
+    "mcp>=1.0",
+]
 
 [project.scripts]
 plan-to-project-install = "scripts.install_codex:main"
+sbr = "scripts.sbr.cli:main"
+sbr-mcp-server = "scripts.sbr.mcp_server:main"
 
 [project.optional-dependencies]
 dev = [
@@ -21,7 +27,7 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["scripts"]
+packages = ["scripts", "scripts.sbr"]
 
 [tool.pytest.ini_options]
 testpaths = ["scripts/tests"]

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -715,15 +715,12 @@ _ISSUE_TYPE_DEFAULTS: dict[str, dict[str, str]] = {
     "Project Scope": {
         "color": "PURPLE",
         "description": (
-            "A cohesive unit of product scope delivered across one or more "
-            "Initiatives."
+            "A cohesive unit of product scope delivered across one or more Initiatives."
         ),
     },
     "Initiative": {
         "color": "BLUE",
-        "description": (
-            "A multi-Epic body of work delivering a named Release Value."
-        ),
+        "description": ("A multi-Epic body of work delivering a named Release Value."),
     },
     "Epic": {
         "color": "GREEN",
@@ -1783,8 +1780,7 @@ def _fill_task_subsections(rendered: str, subs: dict[str, Any]) -> str:
     sc = subs.get("security_compliance")
     if isinstance(sc, str) and sc.strip():
         rendered = rendered.replace(
-            "[Required if task involves create/update/delete/"
-            "resolve/write operations]",
+            "[Required if task involves create/update/delete/resolve/write operations]",
             sc,
         )
 
@@ -1805,7 +1801,7 @@ def _meta_block(item: dict[str, Any], level: str) -> str:
 def _done_when_block(extra: list[str] | None = None) -> str:
     lines = extra or ["[PROJECT-SPECIFIC CRITERION]"]
     criteria = "\n".join(f"- [ ] {c}" for c in lines)
-    return f"## I Know I Am Done When\n\n" f"{criteria}\n" f"{TDD_SENTINEL}\n"
+    return f"## I Know I Am Done When\n\n{criteria}\n{TDD_SENTINEL}\n"
 
 
 def _moscow_block(musts: list[str]) -> str:
@@ -1972,7 +1968,7 @@ def _body_task(item: dict[str, Any], manifest: dict) -> str:
         f"{desc or '[What this task implements]'}\n\n"
         "---\n\n"
         "## Context\n\n"
-        "- **Parent Story AC**: \"[AC text]\"\n"
+        '- **Parent Story AC**: "[AC text]"\n'
         "- **Preceding Task**: None\n"
         "- **Blocking Tasks**: None\n\n"
         "---\n\n"
@@ -2258,8 +2254,6 @@ def _cmd_create(args: argparse.Namespace) -> None:
         hierarchy, allow_shallow=getattr(args, "allow_shallow_subsections", False)
     )
     create_all_issues(hierarchy, config, args.repo, output_dir=out)
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -2733,9 +2727,7 @@ def _cmd_refresh(args: argparse.Namespace) -> None:
         scope_issue_number=args.scope_issue,
         dry_run=args.dry_run,
         skip_issues=skip_issues or None,
-        allow_shallow_subsections=getattr(
-            args, "allow_shallow_subsections", False
-        ),
+        allow_shallow_subsections=getattr(args, "allow_shallow_subsections", False),
     )
     if out:
         out.mkdir(parents=True, exist_ok=True)
@@ -2801,9 +2793,7 @@ def main() -> None:
         "--auto-create-issue-types",
         action="store_true",
         default=False,
-        help=(
-            "FR #46: auto-create missing org Issue Types during preflight."
-        ),
+        help=("FR #46: auto-create missing org Issue Types during preflight."),
     )
 
     p_refresh = sub.add_parser(

--- a/scripts/mint_app_token.py
+++ b/scripts/mint_app_token.py
@@ -243,9 +243,7 @@ def _sign_app_jwt(app_id: str, private_key_pem: bytes) -> str:
     return _pyjwt.encode(payload, private_key_pem, algorithm="RS256")
 
 
-def _http_request(
-    url: str, token: str, method: str = "GET"
-) -> tuple[int, dict]:
+def _http_request(url: str, token: str, method: str = "GET") -> tuple[int, dict]:
     """Minimal GitHub API call (stdlib urllib; no `requests` dependency)."""
     # URL is always hardcoded https://api.github.com/... from the two call
     # sites below; no user-controlled scheme risk.  S310 false positive.

--- a/scripts/queue_order.py
+++ b/scripts/queue_order.py
@@ -176,8 +176,8 @@ def run_queue_order(
     print("\n=== Recommended Queue Order (Stories) ===")
     for i, record in enumerate(ordered, 1):
         print(
-            f"  {i}. #{record['number']} [{record.get('priority','P1')}/"
-            f"{record.get('size','M')}] {record['title']}"
+            f"  {i}. #{record['number']} [{record.get('priority', 'P1')}/"
+            f"{record.get('size', 'M')}] {record['title']}"
         )
 
     output = [

--- a/scripts/sbr/__init__.py
+++ b/scripts/sbr/__init__.py
@@ -1,0 +1,17 @@
+"""Sprint Backlog Review (SBR) — Voice-first, LLM-driven backlog review.
+
+See `docs/plans/kdtix-format/Sprint Backlog Review (KDTIX-format).md` in
+`kdtix-open/agent-project-queue` for the full plan.
+
+Stage 1 MVP (this package):
+    api        — canonical business logic (SessionManager, IssueWalker,
+                 SubsectionReviewer, LLMPromptBuilder, WriteBacker).
+    cli        — `sbr` shell wrapper, thin argparse around api.
+    mcp_server — `sbr-mcp-server`, exposes api as 10 canonical MCP tools.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/scripts/sbr/api.py
+++ b/scripts/sbr/api.py
@@ -1,0 +1,534 @@
+"""SBR API — canonical business logic shared by CLI + MCP server.
+
+Five primary components:
+ - `SessionManager`  — start / resume / pause / advance / terminate.
+                       JSON-persisted at ~/.sbr/sessions/<id>.json.
+ - `IssueWalker`     — wraps the skill's `_walk_existing_hierarchy` from
+                       FR #34 Stage 5 / PR #37 for consistent iteration.
+ - `SubsectionReviewer` — parses issue body via the skill's
+                       `_parse_subsections`, iterates in template order,
+                       yields per-subsection review context.
+ - `LLMPromptBuilder` — produces voice-friendly per-subsection prompts.
+ - `WriteBacker`     — merges approved verdicts + commits via `gh issue edit`
+                       atomically.  Reuses FR #34 Stage 2.5
+                       `_preserve_outside_template_zone`.
+
+Stage 1 MVP focuses on the review orchestration primitives.  Stage 2 UI
+imports this module.  Stage 3 closed-loop wraps the WriteBacker with
+plan-file write-back.  EP-033 Vector/RAG hooks into LLMPromptBuilder.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as _dt
+import json
+import os
+import tempfile
+import uuid
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Literal
+
+# Re-use the skill's canonical walker + parser + template + preserve-zone.
+from scripts.create_issues import (
+    _parse_subsections,
+    _preserve_outside_template_zone,
+    _walk_existing_hierarchy,
+    generate_body,
+)
+from scripts.gh_helpers import get_issue_body, update_issue_body
+
+# Verdict types for per-subsection operator decisions.
+Verdict = Literal["pending", "approved", "improved", "skipped"]
+
+# Subsection iteration order per level — Stage 1 MVP uses the canonical
+# template order so review flows like a reader would naturally encounter
+# the content.
+_SUBSECTION_ORDER_BY_LEVEL: dict[str, list[str]] = {
+    "scope": [
+        "vision",
+        "business_problem",
+        "success_criteria",
+        "in_scope_capabilities",
+        "assumptions",
+        "out_of_scope",
+        "moscow",
+        "done_when",
+    ],
+    "initiative": [
+        "objective",
+        "release_value",
+        "success_criteria",
+        "feature_scope",
+        "assumptions",
+        "dependencies",
+        "out_of_scope",
+        "artifacts",
+        "done_when",
+    ],
+    "epic": [
+        "objective",
+        "release_value",
+        "success_criteria",
+        "feature_scope",
+        "assumptions",
+        "dependencies",
+        "done_when",
+        "code_areas",
+        "questions_tech_lead",
+        "security_compliance",
+    ],
+    "story": [
+        "user_story",
+        "tldr",
+        "why_this_matters",
+        "assumptions",
+        "moscow",
+        "dependencies",
+        "done_when",
+        "acceptance_criteria",
+        "constraints",
+        "implementation_notes",
+        "security_compliance",
+        "subtasks_needed",
+    ],
+    "task": [
+        "summary",
+        "context",
+        "done_when",
+        "implementation_notes",
+        "security_compliance",
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SubsectionReview:
+    """One subsection under review.  Stored per-issue in session state."""
+
+    key: str
+    verdict: Verdict = "pending"
+    original_content: str = ""
+    approved_content: str = ""  # operator's final content (for 'improved' / approved)
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SubsectionReview:
+        return cls(**d)
+
+
+@dataclasses.dataclass
+class IssueReview:
+    """One issue under review.  Holds the queue of SubsectionReview items."""
+
+    number: int
+    title: str
+    level: str
+    parent_number: int | None = None
+    subsections: list[SubsectionReview] = dataclasses.field(default_factory=list)
+    write_back_completed: bool = False
+
+    @property
+    def pending_count(self) -> int:
+        return sum(1 for s in self.subsections if s.verdict == "pending")
+
+    @property
+    def approved_count(self) -> int:
+        return sum(1 for s in self.subsections if s.verdict == "approved")
+
+    @property
+    def improved_count(self) -> int:
+        return sum(1 for s in self.subsections if s.verdict == "improved")
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for s in self.subsections if s.verdict == "skipped")
+
+    def to_dict(self) -> dict[str, Any]:
+        d = dataclasses.asdict(self)
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> IssueReview:
+        subs = [SubsectionReview.from_dict(s) for s in d.get("subsections", [])]
+        return cls(
+            number=d["number"],
+            title=d["title"],
+            level=d["level"],
+            parent_number=d.get("parent_number"),
+            subsections=subs,
+            write_back_completed=d.get("write_back_completed", False),
+        )
+
+
+@dataclasses.dataclass
+class Session:
+    """Top-level SBR session state."""
+
+    session_id: str
+    scope_issue_number: int
+    repo: str
+    created_at: str
+    status: Literal["active", "paused", "completed", "terminated"] = "active"
+    current_issue_index: int = 0
+    current_subsection_index: int = 0
+    skip_issues: list[int] = dataclasses.field(default_factory=list)
+    issues: list[IssueReview] = dataclasses.field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "scope_issue_number": self.scope_issue_number,
+            "repo": self.repo,
+            "created_at": self.created_at,
+            "status": self.status,
+            "current_issue_index": self.current_issue_index,
+            "current_subsection_index": self.current_subsection_index,
+            "skip_issues": list(self.skip_issues),
+            "issues": [i.to_dict() for i in self.issues],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Session:
+        return cls(
+            session_id=d["session_id"],
+            scope_issue_number=d["scope_issue_number"],
+            repo=d["repo"],
+            created_at=d["created_at"],
+            status=d.get("status", "active"),
+            current_issue_index=d.get("current_issue_index", 0),
+            current_subsection_index=d.get("current_subsection_index", 0),
+            skip_issues=list(d.get("skip_issues", [])),
+            issues=[IssueReview.from_dict(i) for i in d.get("issues", [])],
+        )
+
+
+# ---------------------------------------------------------------------------
+# IssueWalker — delegate to the skill's walker
+# ---------------------------------------------------------------------------
+
+
+class IssueWalker:
+    """Walks the sub-issue tree rooted at a Scope issue number.
+
+    Delegates to the skill's `_walk_existing_hierarchy` for consistency —
+    whatever `refresh` sees, SBR sees.  Honors an optional skip-issues set.
+    """
+
+    @staticmethod
+    def walk(
+        repo: str, scope_issue_number: int, skip_issues: Iterable[int] | None = None
+    ) -> list[dict[str, Any]]:
+        skip = set(skip_issues or set())
+        results = _walk_existing_hierarchy(repo, scope_issue_number)
+        if skip:
+            results = [r for r in results if r["number"] not in skip]
+        return results
+
+
+# ---------------------------------------------------------------------------
+# SubsectionReviewer — parse + iterate
+# ---------------------------------------------------------------------------
+
+
+class SubsectionReviewer:
+    """Parses an issue body + produces the ordered list of subsections.
+
+    Stage 1 MVP: iteration order is template-order per level (see
+    `_SUBSECTION_ORDER_BY_LEVEL`).  Iterator yields `(key, original_content)`
+    tuples.  LLMPromptBuilder consumes these to produce narratable
+    summaries + improvement proposals.
+
+    Placeholder detection is deferred to compliance_check's P0-4 scanner;
+    the SubsectionReviewer doesn't re-implement it.
+    """
+
+    @staticmethod
+    def ordered_subsections(level: str, body: str) -> list[SubsectionReview]:
+        """Parse `body` + return a list of SubsectionReview stubs in template
+        order.  Each stub's `original_content` is the parsed value for that
+        key (str / list / dict serialized to string for storage)."""
+        parsed = _parse_subsections(body, level)
+        order = _SUBSECTION_ORDER_BY_LEVEL.get(level, [])
+        result: list[SubsectionReview] = []
+        for key in order:
+            value = parsed.get(key)
+            if value is None:
+                original = ""
+            elif isinstance(value, str):
+                original = value
+            elif isinstance(value, list):
+                original = "\n".join(f"- {v}" for v in value)
+            elif isinstance(value, dict):
+                original = json.dumps(value)
+            else:
+                original = str(value)
+            result.append(SubsectionReview(key=key, original_content=original))
+        return result
+
+
+# ---------------------------------------------------------------------------
+# SessionManager — JSON persistence + state machine
+# ---------------------------------------------------------------------------
+
+
+def _sessions_dir() -> Path:
+    """Returns the per-operator sessions dir.  Override via SBR_SESSIONS_DIR."""
+    override = os.environ.get("SBR_SESSIONS_DIR", "").strip()
+    if override:
+        return Path(os.path.expanduser(override))
+    return Path.home() / ".sbr" / "sessions"
+
+
+class SessionManager:
+    """Manages the SBR session lifecycle + atomic JSON persistence.
+
+    Primary entry points:
+     - `start(scope_issue_number, repo, skip_issues)` → new session
+     - `resume(session_id)` → loads from disk
+     - `get_current_subsection(session_id)` → returns
+       (issue_number, title, level, subsection_key, original_content)
+       for the next pending subsection, or None if the session is complete.
+     - `apply_verdict(session_id, verdict, improved_content=None)`
+       → advances the cursor + persists.
+     - `pause(session_id)` / `resume(session_id)` / `terminate(session_id)`
+       → state transitions.
+
+    All writes go through `_atomic_write` which writes to a tmp file +
+    renames to prevent partial-write corruption.
+    """
+
+    def __init__(self, sessions_dir: Path | None = None) -> None:
+        self.sessions_dir = sessions_dir or _sessions_dir()
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    def _session_path(self, session_id: str) -> Path:
+        return self.sessions_dir / f"{session_id}.json"
+
+    def _atomic_write(self, session: Session) -> None:
+        path = self._session_path(session.session_id)
+        # Write to tmp in the same dir (for atomic rename across FS)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=self.sessions_dir,
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(session.to_dict(), tmp, indent=2)
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(path)
+
+    def start(
+        self,
+        scope_issue_number: int,
+        repo: str,
+        skip_issues: Iterable[int] | None = None,
+    ) -> Session:
+        """Walk the sub-issue tree + build fresh session.  Fetches issue
+        bodies lazily (IssueWalker does NOT fetch bodies — those come
+        later via `get_issue_body` when advancing to each issue)."""
+        walked = IssueWalker.walk(repo, scope_issue_number, skip_issues)
+        # Convert walked entries to IssueReview stubs; subsections empty
+        # until we fetch the body + parse in SubsectionReviewer.
+        issue_reviews: list[IssueReview] = []
+        for entry in walked:
+            issue_reviews.append(
+                IssueReview(
+                    number=entry["number"],
+                    title=entry["title"],
+                    level=entry["level"],
+                    parent_number=entry.get("parent_number"),
+                    subsections=[],  # populated on first visit
+                )
+            )
+        session = Session(
+            session_id=str(uuid.uuid4()),
+            scope_issue_number=scope_issue_number,
+            repo=repo,
+            created_at=_dt.datetime.now(tz=_dt.timezone.utc).isoformat(),
+            status="active",
+            skip_issues=list(skip_issues or []),
+            issues=issue_reviews,
+        )
+        self._atomic_write(session)
+        return session
+
+    def load(self, session_id: str) -> Session:
+        path = self._session_path(session_id)
+        if not path.is_file():
+            raise FileNotFoundError(f"Session not found: {session_id}")
+        with path.open(encoding="utf-8") as f:
+            return Session.from_dict(json.load(f))
+
+    def _populate_current_issue_subsections(self, session: Session) -> None:
+        """Lazily fetch current issue's body + populate subsection stubs."""
+        if session.current_issue_index >= len(session.issues):
+            return
+        current = session.issues[session.current_issue_index]
+        if current.subsections:
+            return  # already populated
+        body = get_issue_body(session.repo, current.number)
+        current.subsections = SubsectionReviewer.ordered_subsections(
+            current.level, body
+        )
+
+    def get_current_subsection(
+        self, session: Session
+    ) -> tuple[IssueReview, SubsectionReview] | None:
+        """Return the (issue, subsection) currently under review, or None
+        if the session has no more pending subsections."""
+        if session.status != "active":
+            return None
+        while session.current_issue_index < len(session.issues):
+            current_issue = session.issues[session.current_issue_index]
+            self._populate_current_issue_subsections(session)
+            if session.current_subsection_index < len(current_issue.subsections):
+                current_sub = current_issue.subsections[
+                    session.current_subsection_index
+                ]
+                return current_issue, current_sub
+            # Advance to next issue
+            session.current_issue_index += 1
+            session.current_subsection_index = 0
+        session.status = "completed"
+        return None
+
+    def apply_verdict(
+        self,
+        session: Session,
+        verdict: Verdict,
+        improved_content: str | None = None,
+    ) -> None:
+        """Mark current subsection with verdict + advance cursor + persist."""
+        pair = self.get_current_subsection(session)
+        if pair is None:
+            return
+        _issue, sub = pair
+        sub.verdict = verdict
+        if verdict == "improved" and improved_content is not None:
+            sub.approved_content = improved_content
+        elif verdict == "approved":
+            sub.approved_content = sub.original_content
+        # Advance cursor
+        session.current_subsection_index += 1
+        self._atomic_write(session)
+
+    def pause(self, session: Session) -> None:
+        session.status = "paused"
+        self._atomic_write(session)
+
+    def resume_session(self, session: Session) -> None:
+        if session.status == "paused":
+            session.status = "active"
+            self._atomic_write(session)
+
+    def terminate(self, session: Session) -> None:
+        session.status = "terminated"
+        self._atomic_write(session)
+
+
+# ---------------------------------------------------------------------------
+# LLMPromptBuilder — Stage 1 MVP scaffolding
+# ---------------------------------------------------------------------------
+
+
+class LLMPromptBuilder:
+    """Produces voice-friendly per-subsection prompts for an LLM.
+
+    Stage 1 MVP: returns static, narratable summary + improvement-proposal
+    templates.  Stage 2+ will integrate with the actual LLM provider (the
+    MCP client's LLM handles the completion; SBR just produces well-shaped
+    prompts).
+
+    EP-033 integration point: `build_improvement_prompt()` will augment
+    prompts with RAG context once the KnowledgeIndex service is available.
+    """
+
+    @staticmethod
+    def build_summary_prompt(level: str, subsection_key: str, content: str) -> str:
+        """Prompt the LLM to narrate a voice-friendly summary."""
+        return (
+            f"Summarize the '{subsection_key}' subsection of this "
+            f"{level}-level issue in 1-2 short sentences suitable for voice "
+            f"narration.  If the content contains template placeholders "
+            f"(bracketed uppercase strings), mention how many need operator "
+            f"attention first.\n\n"
+            f"Content:\n\n{content or '(empty)'}"
+        )
+
+    @staticmethod
+    def build_improvement_prompt(
+        level: str, subsection_key: str, content: str, rag_context: str = ""
+    ) -> str:
+        """Prompt the LLM to propose an improved version of the subsection."""
+        rag_block = (
+            f"\nRelevant prior approvals:\n{rag_context}\n" if rag_context else ""
+        )
+        return (
+            f"Improve the '{subsection_key}' subsection of this "
+            f"{level}-level issue.  Match the template's expected shape "
+            f"(bullet list for criteria, Given/When/Then for acceptance, "
+            f"paragraph for narrative, etc.).  Replace any template "
+            f"placeholders with real content.  Keep the writing concrete + "
+            f"voice-friendly.{rag_block}\n\n"
+            f"Current content:\n\n{content or '(empty)'}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# WriteBacker — merge + commit
+# ---------------------------------------------------------------------------
+
+
+class WriteBacker:
+    """Assembles the final issue body from a completed IssueReview +
+    commits via `gh issue edit`.
+
+    Reuses FR #34 Stage 2.5 `_preserve_outside_template_zone` so operator
+    content outside the template (HTML comments, trailing signatures,
+    sequence-order blockquotes) survives refresh.
+
+    Stage 1 MVP: single-issue write-back.  Callers iterate issues
+    themselves after session completion.
+    """
+
+    @staticmethod
+    def write_back_issue(session: Session, issue: IssueReview) -> dict[str, Any]:
+        """Commit the approved verdicts for a single issue.  Returns a
+        diff summary for operator review."""
+        # Build the item dict expected by generate_body from the session's
+        # approved/improved content.
+        subsections: dict[str, Any] = {}
+        for sub in issue.subsections:
+            if sub.verdict in ("approved", "improved") and sub.approved_content:
+                subsections[sub.key] = sub.approved_content
+        item = {
+            "title": issue.title,
+            "description": "",  # subsections carry the content
+            "priority": "P1",
+            "size": "M",
+            "subsections": subsections,
+        }
+        new_body = generate_body(item, issue.level)
+
+        # Fetch current body + preserve outside-zone content.
+        current_body = get_issue_body(session.repo, issue.number)
+        merged_body, preserved = _preserve_outside_template_zone(current_body, new_body)
+        update_issue_body(session.repo, issue.number, merged_body)
+        issue.write_back_completed = True
+        return {
+            "issue_number": issue.number,
+            "chars_before": len(current_body),
+            "chars_after": len(merged_body),
+            "preserved_prefix_lines": preserved.get("prefix", "").count("\n"),
+            "preserved_suffix_lines": preserved.get("suffix", "").count("\n"),
+        }

--- a/scripts/sbr/cli.py
+++ b/scripts/sbr/cli.py
@@ -1,0 +1,360 @@
+"""SBR CLI — thin argparse wrapper over api.
+
+Mirror-surface of the MCP server's 10 canonical tools, shell-friendly
+for CI scripts + automation.  Primary operator UI is the MCP server
+(Claude App with Voice); the CLI is for scripted / headless use.
+
+Subcommands (Stage 1 MVP):
+  start      — begin a new review session
+  next       — advance to next pending subsection; print summary
+  verbatim   — print current subsection verbatim (voice-unfriendly but explicit)
+  approve    — accept current subsection content; advance
+  improve    — replace current subsection with given text; advance
+  skip       — leave current subsection untouched; advance
+  status     — print session progress
+  pause      — halt session (resumes from same cursor on next `resume`)
+  resume     — re-activate a paused session
+  terminate  — stop session without write-back
+  write-back — commit approved verdicts for all completed issues
+
+The CLI uses a sticky session via ~/.sbr/current-session.txt so operators
+don't need to retype the session id.  Pass `--session <id>` to override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from scripts.sbr.api import Session, SessionManager
+
+
+def _current_session_file() -> Path:
+    override = os.environ.get("SBR_CURRENT_SESSION_FILE", "").strip()
+    if override:
+        return Path(os.path.expanduser(override))
+    return Path.home() / ".sbr" / "current-session.txt"
+
+
+def _store_current_session(session_id: str) -> None:
+    path = _current_session_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(session_id, encoding="utf-8")
+
+
+def _load_current_session() -> str | None:
+    path = _current_session_file()
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8").strip() or None
+
+
+def _resolve_session(mgr: SessionManager, args: argparse.Namespace) -> Session:
+    session_id = getattr(args, "session", None) or _load_current_session()
+    if not session_id:
+        print(
+            "[sbr] No session ID provided and no sticky session found.\n"
+            "  Start a session with `sbr start --scope N --repo owner/name`\n"
+            "  or pass `--session <id>` explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        return mgr.load(session_id)
+    except FileNotFoundError as exc:
+        print(f"[sbr] {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _render_output(payload: dict, fmt: str) -> None:
+    """Render a payload in the requested format.
+
+    `text` — human-narratable one-liner (voice-friendly for LLM speech).
+    `json` — machine-readable for scripted pipelines.
+    """
+    if fmt == "json":
+        print(json.dumps(payload, indent=2))
+        return
+    # text format: prefer narratable summary if present
+    if "narrative" in payload:
+        print(payload["narrative"])
+    else:
+        # Fallback: flat key=value lines
+        for k, v in payload.items():
+            print(f"{k}: {v}")
+
+
+def _cmd_start(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    skip = set(args.skip_issue or [])
+    session = mgr.start(args.scope, args.repo, skip_issues=skip)
+    _store_current_session(session.session_id)
+    total = len(session.issues)
+    narrative = (
+        f"Session started.  {total} issues queued under scope "
+        f"#{session.scope_issue_number} in {session.repo}.  "
+        f"Session id: {session.session_id}."
+    )
+    _render_output(
+        {
+            "session_id": session.session_id,
+            "queue_size": total,
+            "scope_issue_number": session.scope_issue_number,
+            "repo": session.repo,
+            "narrative": narrative,
+        },
+        args.format,
+    )
+    return 0
+
+
+def _cmd_next(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    pair = mgr.get_current_subsection(session)
+    if pair is None:
+        _render_output(
+            {
+                "status": session.status,
+                "narrative": (
+                    "Session complete.  Run `sbr write-back` to commit "
+                    "approved verdicts, or `sbr terminate` to discard."
+                ),
+            },
+            args.format,
+        )
+        return 0
+    # Re-persist in case lazy populate created subsections
+    mgr._atomic_write(session)
+    issue, sub = pair
+    has_content = bool(sub.original_content.strip())
+    narrative = f"Issue #{issue.number}: {sub.key}.  " + (
+        "Content present; review + approve or improve."
+        if has_content
+        else "This subsection is empty.  Propose an improvement."
+    )
+    _render_output(
+        {
+            "has_next": True,
+            "issue_number": issue.number,
+            "issue_title": issue.title,
+            "subsection_key": sub.key,
+            "has_content": has_content,
+            "content_length": len(sub.original_content),
+            "narrative": narrative,
+        },
+        args.format,
+    )
+    return 0
+
+
+def _cmd_verbatim(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    pair = mgr.get_current_subsection(session)
+    if pair is None:
+        print("[sbr] No current subsection — session may be complete.", file=sys.stderr)
+        return 1
+    _issue, sub = pair
+    # Verbatim content always prints directly (no JSON wrapping) so Voice
+    # narration reads the exact source text.
+    print(sub.original_content or "(empty)")
+    return 0
+
+
+def _cmd_approve(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    mgr.apply_verdict(session, "approved")
+    _render_output(
+        {"status": "approved", "narrative": "Approved.  Advancing."}, args.format
+    )
+    return 0
+
+
+def _cmd_improve(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    content = args.content
+    # Support reading from stdin when content is "-"
+    if content == "-":
+        content = sys.stdin.read()
+    mgr.apply_verdict(session, "improved", improved_content=content)
+    _render_output(
+        {
+            "status": "improved",
+            "content_length": len(content),
+            "narrative": "Improved.  Advancing.",
+        },
+        args.format,
+    )
+    return 0
+
+
+def _cmd_skip(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    mgr.apply_verdict(session, "skipped")
+    _render_output(
+        {"status": "skipped", "narrative": "Skipped.  Advancing."}, args.format
+    )
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    completed = sum(1 for i in session.issues if i.pending_count == 0)
+    total_issues = len(session.issues)
+    total_sections = sum(len(i.subsections) for i in session.issues)
+    approved = sum(i.approved_count for i in session.issues)
+    improved = sum(i.improved_count for i in session.issues)
+    skipped = sum(i.skipped_count for i in session.issues)
+    narrative = (
+        f"Session {session.status}.  "
+        f"Issue {session.current_issue_index + 1} of {total_issues}.  "
+        f"{approved} approved, {improved} improved, {skipped} skipped."
+    )
+    _render_output(
+        {
+            "session_id": session.session_id,
+            "status": session.status,
+            "current_issue_index": session.current_issue_index,
+            "total_issues": total_issues,
+            "issues_completed": completed,
+            "total_sections": total_sections,
+            "approved": approved,
+            "improved": improved,
+            "skipped": skipped,
+            "narrative": narrative,
+        },
+        args.format,
+    )
+    return 0
+
+
+def _cmd_pause(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    mgr.pause(session)
+    _render_output({"status": "paused", "narrative": "Session paused."}, args.format)
+    return 0
+
+
+def _cmd_resume(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    mgr.resume_session(session)
+    _render_output({"status": "active", "narrative": "Session resumed."}, args.format)
+    return 0
+
+
+def _cmd_terminate(args: argparse.Namespace) -> int:
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    mgr.terminate(session)
+    _render_output(
+        {"status": "terminated", "narrative": "Session terminated."}, args.format
+    )
+    return 0
+
+
+def _cmd_write_back(args: argparse.Namespace) -> int:
+    from scripts.sbr.api import WriteBacker
+
+    mgr = SessionManager()
+    session = _resolve_session(mgr, args)
+    results: list[dict] = []
+    for issue in session.issues:
+        if issue.write_back_completed:
+            continue
+        # Only write-back issues that have at least one approved/improved verdict
+        if not any(s.verdict in ("approved", "improved") for s in issue.subsections):
+            continue
+        result = WriteBacker.write_back_issue(session, issue)
+        results.append(result)
+    mgr._atomic_write(session)
+    _render_output(
+        {
+            "write_back_count": len(results),
+            "results": results,
+            "narrative": f"Wrote back {len(results)} issue(s).",
+        },
+        args.format,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sbr",
+        description="Sprint Backlog Review — voice-friendly backlog review CLI.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text, voice-friendly).",
+    )
+    parser.add_argument(
+        "--session",
+        help="Session ID (defaults to ~/.sbr/current-session.txt).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_start = sub.add_parser("start", help="Start a new review session.")
+    p_start.add_argument("--scope", required=True, type=int, help="Scope issue number.")
+    p_start.add_argument("--repo", required=True, help="owner/name.")
+    p_start.add_argument(
+        "--skip-issue",
+        action="append",
+        type=int,
+        default=None,
+        help="Issue number(s) to skip (repeatable).",
+    )
+    p_start.set_defaults(func=_cmd_start)
+
+    p_next = sub.add_parser("next", help="Advance to next pending subsection.")
+    p_next.set_defaults(func=_cmd_next)
+
+    p_verbatim = sub.add_parser("verbatim", help="Print current subsection verbatim.")
+    p_verbatim.set_defaults(func=_cmd_verbatim)
+
+    p_approve = sub.add_parser("approve", help="Approve current subsection + advance.")
+    p_approve.set_defaults(func=_cmd_approve)
+
+    p_improve = sub.add_parser("improve", help="Replace current subsection + advance.")
+    p_improve.add_argument("content", help="New content (or `-` to read from stdin).")
+    p_improve.set_defaults(func=_cmd_improve)
+
+    p_skip = sub.add_parser(
+        "skip", help="Skip current subsection (no change) + advance."
+    )
+    p_skip.set_defaults(func=_cmd_skip)
+
+    p_status = sub.add_parser("status", help="Print session progress.")
+    p_status.set_defaults(func=_cmd_status)
+
+    p_pause = sub.add_parser("pause", help="Pause session.")
+    p_pause.set_defaults(func=_cmd_pause)
+
+    p_resume = sub.add_parser("resume", help="Resume paused session.")
+    p_resume.set_defaults(func=_cmd_resume)
+
+    p_terminate = sub.add_parser(
+        "terminate", help="Terminate session without write-back."
+    )
+    p_terminate.set_defaults(func=_cmd_terminate)
+
+    p_wb = sub.add_parser("write-back", help="Commit approved verdicts to GitHub.")
+    p_wb.set_defaults(func=_cmd_write_back)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sbr/mcp_server.py
+++ b/scripts/sbr/mcp_server.py
@@ -1,0 +1,221 @@
+"""SBR MCP Server — exposes the SBR API as MCP tools.
+
+Primary operator interface for Stage 1 MVP.  Claude App (with Voice),
+Claude CLI, Codex, Cursor, and VS Code all drive review via the same
+tool surface.
+
+10 canonical tools mirror the CLI subcommands:
+  sbr_start_session      / sbr_status
+  sbr_next_subsection    / sbr_current_subsection_verbatim
+  sbr_approve            / sbr_improve             / sbr_skip
+  sbr_pause              / sbr_resume              / sbr_write_back
+  sbr_terminate
+
+Uses the `mcp` Python SDK (https://github.com/modelcontextprotocol/python-sdk).
+If `mcp` is not available at import time, the module prints a clear
+remediation hint + exits when `main()` is called.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError:  # pragma: no cover — import-time graceful failure
+    FastMCP = None  # type: ignore[assignment]
+
+from scripts.sbr.api import SessionManager, WriteBacker
+
+
+def _build_server() -> FastMCP:  # type: ignore[name-defined]
+    """Construct the FastMCP server + register the 10 canonical tools.
+
+    Delegates every tool to `scripts.sbr.api` primitives; no business logic
+    lives in the MCP layer.  Sticky-session support uses the same
+    `~/.sbr/current-session.txt` file as the CLI.
+    """
+    if FastMCP is None:
+        raise RuntimeError(
+            "The `mcp` Python SDK is not installed.\n"
+            "  pip install mcp  (see https://github.com/modelcontextprotocol/python-sdk)"
+        )
+
+    mcp = FastMCP("sbr")
+    mgr = SessionManager()
+
+    @mcp.tool()
+    def sbr_start_session(
+        scope_issue_number: int, repo: str, skip_issues: list[int] | None = None
+    ) -> dict[str, Any]:
+        """Start a new Sprint Backlog Review session rooted at a Project Scope issue.
+
+        Args:
+            scope_issue_number: The Project Scope issue number in the repo (e.g. 357).
+            repo: owner/name (e.g. "kdtix-open/agent-project-queue").
+            skip_issues: Optional list of issue numbers to exclude from review.
+
+        Returns:
+            {session_id, queue_size, scope_issue_number, repo}
+        """
+        session = mgr.start(
+            scope_issue_number, repo, skip_issues=set(skip_issues or set())
+        )
+        return {
+            "session_id": session.session_id,
+            "queue_size": len(session.issues),
+            "scope_issue_number": session.scope_issue_number,
+            "repo": session.repo,
+            "status": session.status,
+        }
+
+    @mcp.tool()
+    def sbr_next_subsection(session_id: str) -> dict[str, Any]:
+        """Advance to the next pending subsection in the session.
+
+        Returns a summary describing the current issue + subsection + whether
+        content is present.  When the session has no more pending subsections,
+        `has_next` is False.
+        """
+        session = mgr.load(session_id)
+        pair = mgr.get_current_subsection(session)
+        mgr._atomic_write(session)  # persist lazy-populated subsections
+        if pair is None:
+            return {
+                "has_next": False,
+                "status": session.status,
+                "message": (
+                    "Session complete.  Run sbr_write_back to commit approved "
+                    "verdicts, or sbr_terminate to discard."
+                ),
+            }
+        issue, sub = pair
+        return {
+            "has_next": True,
+            "issue_number": issue.number,
+            "issue_title": issue.title,
+            "issue_level": issue.level,
+            "subsection_key": sub.key,
+            "has_content": bool(sub.original_content.strip()),
+            "content_length": len(sub.original_content),
+        }
+
+    @mcp.tool()
+    def sbr_current_subsection_verbatim(session_id: str) -> dict[str, Any]:
+        """Return the verbatim (unsummarized) content of the current subsection.
+
+        Use when the operator asks to hear the original text instead of an
+        LLM-summarized version.
+        """
+        session = mgr.load(session_id)
+        pair = mgr.get_current_subsection(session)
+        if pair is None:
+            return {"has_current": False, "content": ""}
+        _issue, sub = pair
+        return {
+            "has_current": True,
+            "subsection_key": sub.key,
+            "content": sub.original_content,
+        }
+
+    @mcp.tool()
+    def sbr_approve(session_id: str) -> dict[str, Any]:
+        """Approve the current subsection as-is + advance."""
+        session = mgr.load(session_id)
+        mgr.apply_verdict(session, "approved")
+        return {"status": "approved", "session_status": session.status}
+
+    @mcp.tool()
+    def sbr_improve(session_id: str, new_content: str) -> dict[str, Any]:
+        """Replace the current subsection with improved content + advance."""
+        session = mgr.load(session_id)
+        mgr.apply_verdict(session, "improved", improved_content=new_content)
+        return {
+            "status": "improved",
+            "session_status": session.status,
+            "content_length": len(new_content),
+        }
+
+    @mcp.tool()
+    def sbr_skip(session_id: str) -> dict[str, Any]:
+        """Skip the current subsection (leave as-is) + advance."""
+        session = mgr.load(session_id)
+        mgr.apply_verdict(session, "skipped")
+        return {"status": "skipped", "session_status": session.status}
+
+    @mcp.tool()
+    def sbr_pause(session_id: str) -> dict[str, Any]:
+        """Pause the session (preserves cursor for resume)."""
+        session = mgr.load(session_id)
+        mgr.pause(session)
+        return {"status": "paused", "session_status": session.status}
+
+    @mcp.tool()
+    def sbr_resume(session_id: str) -> dict[str, Any]:
+        """Resume a paused session."""
+        session = mgr.load(session_id)
+        mgr.resume_session(session)
+        return {"status": "active", "session_status": session.status}
+
+    @mcp.tool()
+    def sbr_terminate(session_id: str) -> dict[str, Any]:
+        """Terminate a session without write-back (discards verdicts)."""
+        session = mgr.load(session_id)
+        mgr.terminate(session)
+        return {"status": "terminated", "session_status": session.status}
+
+    @mcp.tool()
+    def sbr_session_status(session_id: str) -> dict[str, Any]:
+        """Return the session's current progress snapshot."""
+        session = mgr.load(session_id)
+        approved = sum(i.approved_count for i in session.issues)
+        improved = sum(i.improved_count for i in session.issues)
+        skipped = sum(i.skipped_count for i in session.issues)
+        return {
+            "session_id": session.session_id,
+            "status": session.status,
+            "current_issue_index": session.current_issue_index,
+            "total_issues": len(session.issues),
+            "approved": approved,
+            "improved": improved,
+            "skipped": skipped,
+        }
+
+    @mcp.tool()
+    def sbr_write_back(session_id: str) -> dict[str, Any]:
+        """Commit approved verdicts for all completed issues in the session."""
+        session = mgr.load(session_id)
+        results: list[dict[str, Any]] = []
+        for issue in session.issues:
+            if issue.write_back_completed:
+                continue
+            if not any(
+                s.verdict in ("approved", "improved") for s in issue.subsections
+            ):
+                continue
+            results.append(WriteBacker.write_back_issue(session, issue))
+        mgr._atomic_write(session)
+        return {"write_back_count": len(results), "results": results}
+
+    return mcp
+
+
+def main() -> int:
+    """Entry point for the `sbr-mcp-server` console script.
+
+    Starts the FastMCP server in stdio mode (the default expected by
+    Claude App + most MCP clients).  HTTP transport can be added in
+    Stage 2 if needed.
+    """
+    try:
+        mcp = _build_server()
+    except RuntimeError as exc:
+        print(f"[sbr-mcp-server] {exc}", file=sys.stderr)
+        return 2
+    mcp.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_codex_installer.py
+++ b/scripts/tests/test_codex_installer.py
@@ -53,7 +53,10 @@ class TestCodexInstaller:
         pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
         pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
-        assert pyproject["tool"]["setuptools"]["packages"] == ["scripts"]
+        assert pyproject["tool"]["setuptools"]["packages"] == [
+            "scripts",
+            "scripts.sbr",
+        ]
 
     def test_home_skill_installs_under_codex_home(self, tmp_path: Path) -> None:
         source_root = tmp_path / "source"

--- a/scripts/tests/test_create_issues.py
+++ b/scripts/tests/test_create_issues.py
@@ -209,9 +209,9 @@ class TestGenerateBody:
         }
         for level in ("scope", "initiative", "epic", "story", "task"):
             body = create_issues.generate_body(base_item, level)
-            assert (
-                "I Know I Am Done When" in body
-            ), f"Level '{level}' body missing 'I Know I Am Done When'"
+            assert "I Know I Am Done When" in body, (
+                f"Level '{level}' body missing 'I Know I Am Done When'"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -258,9 +258,9 @@ class TestPreflight:
         mock_run.side_effect = self._make_run_side_effect(tmp_path)
         config = create_issues.preflight("kdtix-open", "kdtix-open/test-repo", 8)
         for level in ("scope", "initiative", "epic", "story", "task"):
-            assert (
-                level in config["issue_type_ids"]
-            ), f"issue_type_ids must have '{level}'"
+            assert level in config["issue_type_ids"], (
+                f"issue_type_ids must have '{level}'"
+            )
 
     @patch("scripts.gh_helpers.subprocess.run")
     def test_preflight_returns_all_three_field_ids(

--- a/scripts/tests/test_ep001_skill_structure.py
+++ b/scripts/tests/test_ep001_skill_structure.py
@@ -43,9 +43,9 @@ class TestSkillMd:
         assert frontmatter["name"], "name must be non-empty"
 
     def test_frontmatter_name_is_kebab_case(self, frontmatter: dict) -> None:
-        assert (
-            frontmatter["name"] == "plan-to-project"
-        ), "name must be 'plan-to-project'"
+        assert frontmatter["name"] == "plan-to-project", (
+            "name must be 'plan-to-project'"
+        )
 
     def test_frontmatter_has_description(self, frontmatter: dict) -> None:
         assert "description" in frontmatter, "frontmatter must have 'description'"
@@ -55,9 +55,9 @@ class TestSkillMd:
     def test_all_9_phases_documented(self, skill_md: str) -> None:
         """SKILL.md must document all 9 workflow phases."""
         for phase_num in range(1, 10):
-            assert (
-                f"Phase {phase_num}" in skill_md
-            ), f"SKILL.md must document Phase {phase_num}"
+            assert f"Phase {phase_num}" in skill_md, (
+                f"SKILL.md must document Phase {phase_num}"
+            )
 
     def test_inputs_table_present(self, skill_md: str) -> None:
         assert "PLAN_FILE" in skill_md, "Inputs table must document PLAN_FILE"
@@ -66,9 +66,9 @@ class TestSkillMd:
         assert "PROJECT_NUMBER" in skill_md, "Inputs table must document PROJECT_NUMBER"
 
     def test_design_decisions_section_present(self, skill_md: str) -> None:
-        assert (
-            "Design Decision" in skill_md
-        ), "SKILL.md must have a Design Decisions section"
+        assert "Design Decision" in skill_md, (
+            "SKILL.md must have a Design Decisions section"
+        )
 
     def test_references_all_scripts(self, skill_md: str) -> None:
         for script in [
@@ -147,18 +147,18 @@ class TestBundledAssets:
     @pytest.mark.parametrize("template", TEMPLATES)
     def test_template_has_tdd_sentinel(self, assets_dir: Path, template: str) -> None:
         content = (assets_dir / template).read_text(encoding="utf-8")
-        assert (
-            "TDD followed" in content
-        ), f"assets/{template} must include TDD sentinel in I Know I Am Done When"
+        assert "TDD followed" in content, (
+            f"assets/{template} must include TDD sentinel in I Know I Am Done When"
+        )
 
     @pytest.mark.parametrize("template", TEMPLATES)
     def test_template_has_done_when_section(
         self, assets_dir: Path, template: str
     ) -> None:
         content = (assets_dir / template).read_text(encoding="utf-8")
-        assert (
-            "I Know I Am Done When" in content
-        ), f"assets/{template} must have 'I Know I Am Done When' section"
+        assert "I Know I Am Done When" in content, (
+            f"assets/{template} must have 'I Know I Am Done When' section"
+        )
 
     def test_story_template_has_user_story_block(self, assets_dir: Path) -> None:
         content = (assets_dir / "template-story.md").read_text(encoding="utf-8")
@@ -171,15 +171,15 @@ class TestBundledAssets:
 
     def test_epic_template_has_security_section(self, assets_dir: Path) -> None:
         content = (assets_dir / "template-epic.md").read_text(encoding="utf-8")
-        assert (
-            "Security" in content
-        ), "Epic template must have Security/Compliance section"
+        assert "Security" in content, (
+            "Epic template must have Security/Compliance section"
+        )
 
     def test_task_template_has_security_section(self, assets_dir: Path) -> None:
         content = (assets_dir / "template-task.md").read_text(encoding="utf-8")
-        assert (
-            "Security" in content
-        ), "Task template must have Security/Compliance section"
+        assert "Security" in content, (
+            "Task template must have Security/Compliance section"
+        )
 
 
 class TestReferenceDocuments:
@@ -221,9 +221,9 @@ class TestReferenceDocuments:
 
     def test_gh_cli_patterns_uses_utf8_encoding(self, references_dir: Path) -> None:
         content = (references_dir / "gh-cli-patterns.md").read_text(encoding="utf-8")
-        assert (
-            "utf-8" in content.lower()
-        ), "gh-cli-patterns.md must document utf-8 encoding"
+        assert "utf-8" in content.lower(), (
+            "gh-cli-patterns.md must document utf-8 encoding"
+        )
 
     def test_compliance_rules_has_p0_p1_p2(self, references_dir: Path) -> None:
         content = (references_dir / "compliance-rules.md").read_text(encoding="utf-8")
@@ -277,25 +277,25 @@ class TestOpenAIYaml:
         iface = openai_yaml["interface"]
         assert "short_description" in iface, "interface must have short_description"
         desc = iface["short_description"]
-        assert (
-            25 <= len(desc) <= 64
-        ), f"short_description must be 25-64 chars, got {len(desc)}: '{desc}'"
+        assert 25 <= len(desc) <= 64, (
+            f"short_description must be 25-64 chars, got {len(desc)}: '{desc}'"
+        )
 
     def test_has_default_prompt(self, openai_yaml: dict) -> None:
         iface = openai_yaml["interface"]
         assert "default_prompt" in iface, "interface must have default_prompt"
-        assert (
-            "$plan-to-project" in iface["default_prompt"]
-        ), "default_prompt must reference $plan-to-project"
+        assert "$plan-to-project" in iface["default_prompt"], (
+            "default_prompt must reference $plan-to-project"
+        )
 
     def test_display_name_matches_skill(self) -> None:
         skill_path = SKILL_ROOT / "SKILL.md"
         openai_path = SKILL_ROOT / "agents" / "openai.yaml"
         skill_text = skill_path.read_text(encoding="utf-8")
         openai_data = yaml.safe_load(openai_path.read_text(encoding="utf-8"))
-        assert (
-            "plan-to-project" in skill_text
-        ), "SKILL.md must reference plan-to-project"
+        assert "plan-to-project" in skill_text, (
+            "SKILL.md must reference plan-to-project"
+        )
         assert openai_data["interface"]["display_name"], "display_name must be set"
 
     def test_does_not_require_github_mcp_server(self, openai_yaml: dict) -> None:
@@ -308,9 +308,9 @@ class TestOpenAIYaml:
             and tool.get("type") == "mcp"
             and tool.get("value") == "github"
         ]
-        assert (
-            not github_mcp_tools
-        ), "openai.yaml should not require GitHub MCP for this CLI-based skill"
+        assert not github_mcp_tools, (
+            "openai.yaml should not require GitHub MCP for this CLI-based skill"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -980,7 +980,7 @@ class TestFR53TddSentinelDedup:
         }
         rendered = create_issues.generate_body(item, "story")
         # Count lines that mention TDD — should be exactly 1 (operator's bullet)
-        tdd_lines = [l for l in rendered.splitlines() if "TDD followed" in l]
+        tdd_lines = [line for line in rendered.splitlines() if "TDD followed" in line]
         assert len(tdd_lines) == 1, (
             f"expected 1 TDD line, got {len(tdd_lines)}: {tdd_lines}"
         )
@@ -1160,9 +1160,7 @@ class TestFR45RequiredSubsectionGate:
             "stories": [],
             "tasks": [],
         }
-        gaps = create_issues.enforce_subsection_schema(
-            hierarchy, allow_shallow=True
-        )
+        gaps = create_issues.enforce_subsection_schema(hierarchy, allow_shallow=True)
         # gaps returned even when allow_shallow; operator sees warning but
         # execution continues
         assert len(gaps) == 1
@@ -2326,7 +2324,7 @@ class TestSubsectionParser:
     def test_unrecognized_heading_stays_as_content(self):
         from scripts import create_issues
 
-        body = "#### Implementation Notes\n\n" "### Approach\n\n" "Do X then Y.\n"
+        body = "#### Implementation Notes\n\n### Approach\n\nDo X then Y.\n"
         subs = create_issues._parse_subsections(body, "task")
         # Unrecognized `### Approach` is not a new subsection — it remains
         # inside Implementation Notes as content.
@@ -2623,7 +2621,7 @@ class TestRenderTaskSubsections:
         from scripts import create_issues
 
         item = self._task_item(
-            "#### Implementation Notes\n\n### Approach\n" "Use regex then pandas.\n"
+            "#### Implementation Notes\n\n### Approach\nUse regex then pandas.\n"
         )
         body = create_issues.generate_body(item, "task")
         assert "[How to implement this" not in body
@@ -2742,7 +2740,7 @@ class TestMermaidDiagramParser:
         the parser still captures the content."""
         from scripts import create_issues
 
-        body = "#### Flowchart\n\n" "flowchart LR\n    A-->B\n    B-->C\n"
+        body = "#### Flowchart\n\nflowchart LR\n    A-->B\n    B-->C\n"
         subs = create_issues._parse_subsections(body, "epic")
         assert len(subs["diagrams"]) == 1
         assert subs["diagrams"][0]["type"] == "flowchart"
@@ -2752,8 +2750,7 @@ class TestMermaidDiagramParser:
         from scripts import create_issues
 
         body_template = (
-            "#### Sequence Diagram\n\n"
-            "```mermaid\nsequenceDiagram\n    A->>B: x\n```\n"
+            "#### Sequence Diagram\n\n```mermaid\nsequenceDiagram\n    A->>B: x\n```\n"
         )
         for level in ("scope", "initiative", "epic", "story", "task"):
             subs = create_issues._parse_subsections(body_template, level)
@@ -2790,8 +2787,7 @@ class TestMermaidDiagramRenderer:
         from scripts import create_issues
 
         body = (
-            "#### Sequence Diagram\n\n"
-            "```mermaid\nsequenceDiagram\n    A->>B: x\n```\n"
+            "#### Sequence Diagram\n\n```mermaid\nsequenceDiagram\n    A->>B: x\n```\n"
         )
         item = {
             "title": "Test",
@@ -2843,7 +2839,7 @@ class TestMermaidDiagramRenderer:
         """Task template has no [DIAGRAMS_HOOK_TASK] placeholder."""
         from scripts import create_issues
 
-        body = "#### Flowchart\n\n" "```mermaid\nflowchart LR\n    A-->B\n```\n"
+        body = "#### Flowchart\n\n```mermaid\nflowchart LR\n    A-->B\n```\n"
         item = {
             "title": "Test",
             "description": body,
@@ -2919,6 +2915,6 @@ class TestP0_5MermaidValidation:
         """`FlowChart LR` (mixed case) is still recognized as valid."""
         from scripts import compliance_check
 
-        body = "```mermaid\n" "FlowChart LR\n" "    A --> B\n" "```\n"
+        body = "```mermaid\nFlowChart LR\n    A --> B\n```\n"
         gaps = compliance_check.check_issue(1, "Test", body, "scope")
         assert not [g for g in gaps if g.get("rule") == "P0-5"]

--- a/scripts/tests/test_integration.py
+++ b/scripts/tests/test_integration.py
@@ -270,9 +270,9 @@ class TestIntegrationCreateAllIssues:
         )
         story_idxs = [i for i, t in enumerate(call_titles) if "Story:" in t]
         assert scope_idx is not None
-        assert all(
-            scope_idx < idx for idx in story_idxs
-        ), "Scope must be created before all stories"
+        assert all(scope_idx < idx for idx in story_idxs), (
+            "Scope must be created before all stories"
+        )
 
     @patch("scripts.create_issues._get_issue_ids")
     @patch("scripts.create_issues._create_issue")
@@ -587,9 +587,9 @@ class TestIntegrationFullPipeline:
             labels_map=labels_map,
         )
         assert isinstance(ordered, list)
-        assert all(
-            r["level"] == "story" for r in ordered
-        ), "Queue should only contain stories"
+        assert all(r["level"] == "story" for r in ordered), (
+            "Queue should only contain stories"
+        )
         # P0 story must come before P1 story
         if len(ordered) >= 2:
             assert ordered[0]["priority"] == "P0"

--- a/scripts/tests/test_mint_app_token.py
+++ b/scripts/tests/test_mint_app_token.py
@@ -50,9 +50,7 @@ class TestLoadConfig:
         assert b"BEGIN" in pem_bytes
         assert "env(key_path)" in source
 
-    def test_load_config_from_env_github_names_inline_pem(
-        self, tmp_path, monkeypatch
-    ):
+    def test_load_config_from_env_github_names_inline_pem(self, tmp_path, monkeypatch):
         """FR #49 patch: GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY take precedence."""
         _clear_all_env(monkeypatch)
         key_path = _generate_test_keypair(tmp_path)
@@ -92,9 +90,7 @@ class TestLoadConfig:
         key = _generate_test_keypair(tmp_path)
         (tmp_path / ".sdlca").mkdir()
         conf = tmp_path / ".sdlca" / "app.conf"
-        conf.write_text(
-            f'SDLCA_APP_ID="99999"\nSDLCA_APP_PRIVATE_KEY_PATH="{key}"\n'
-        )
+        conf.write_text(f'SDLCA_APP_ID="99999"\nSDLCA_APP_PRIVATE_KEY_PATH="{key}"\n')
         monkeypatch.setattr(mint_app_token.Path, "home", lambda: tmp_path)
 
         app_id, pem_bytes, source = mint_app_token._load_config()
@@ -133,9 +129,7 @@ class TestLoadConfig:
         captured = capsys.readouterr()
         assert "does not look like PEM" in captured.err
 
-    def test_load_config_key_path_not_found_exits(
-        self, tmp_path, monkeypatch, capsys
-    ):
+    def test_load_config_key_path_not_found_exits(self, tmp_path, monkeypatch, capsys):
         _clear_all_env(monkeypatch)
         monkeypatch.setenv("SDLCA_APP_ID", "12345")
         monkeypatch.setenv(
@@ -173,9 +167,7 @@ class TestSignAppJwt:
 
 
 class TestMintForOrg:
-    def test_mint_auto_discovers_installation_and_mints(
-        self, tmp_path, monkeypatch
-    ):
+    def test_mint_auto_discovers_installation_and_mints(self, tmp_path, monkeypatch):
         key = _generate_test_keypair(tmp_path)
         monkeypatch.setenv("SDLCA_APP_ID", "12345")
         monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
@@ -201,9 +193,7 @@ class TestMintForOrg:
         assert result["expires_at"] == "2026-04-22T08:00:00Z"
         assert result["installation_id"] == 9876543
 
-    def test_mint_respects_explicit_installation_id_env(
-        self, tmp_path, monkeypatch
-    ):
+    def test_mint_respects_explicit_installation_id_env(self, tmp_path, monkeypatch):
         key = _generate_test_keypair(tmp_path)
         monkeypatch.setenv("SDLCA_APP_ID", "12345")
         monkeypatch.setenv("SDLCA_APP_PRIVATE_KEY_PATH", str(key))
@@ -223,9 +213,7 @@ class TestMintForOrg:
             result = mint_app_token.mint_for_org("kdtix-open")
 
         # Discovery endpoint should NOT be called when env override present
-        assert not any(
-            u.endswith("/orgs/kdtix-open/installation") for u in call_urls
-        )
+        assert not any(u.endswith("/orgs/kdtix-open/installation") for u in call_urls)
         # Mint endpoint uses the explicit installation ID
         assert any(u.endswith("/installations/11111/access_tokens") for u in call_urls)
         assert result["installation_id"] == 11111

--- a/scripts/tests/test_plan_parser.py
+++ b/scripts/tests/test_plan_parser.py
@@ -211,9 +211,9 @@ class TestParsePlanItemFields:
     def test_initiative_has_all_required_fields(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))
         for field in self.REQUIRED_FIELDS:
-            assert (
-                field in result["initiative"]
-            ), f"initiative must have field '{field}'"
+            assert field in result["initiative"], (
+                f"initiative must have field '{field}'"
+            )
 
     def test_epic_has_all_required_fields_plus_parent_ref(self, tmp_plan):
         result = create_issues.parse_plan(str(tmp_plan(MINIMAL_PLAN)))

--- a/scripts/tests/test_sbr_api.py
+++ b/scripts/tests/test_sbr_api.py
@@ -1,0 +1,285 @@
+"""Tests for scripts/sbr/api.py — SBR Stage 1 MVP core."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts.sbr import api
+
+# ---------------------------------------------------------------------------
+# SubsectionReviewer — iteration order + content extraction
+# ---------------------------------------------------------------------------
+
+
+class TestSubsectionReviewerOrdering:
+    def test_scope_level_returns_ordered_subsections(self):
+        body = (
+            "Vision paragraph.\n\n"
+            "#### Business Problem\nLegacy path broken.\n\n"
+            "#### Success Criteria\n- A\n- B\n\n"
+            "#### I Know I Am Done When\n- complete\n"
+        )
+        subs = api.SubsectionReviewer.ordered_subsections("scope", body)
+        keys = [s.key for s in subs]
+        assert keys[0] == "vision"
+        # business_problem should precede success_criteria
+        assert keys.index("business_problem") < keys.index("success_criteria")
+        # done_when should be last
+        assert keys[-1] == "done_when"
+
+    def test_story_level_iteration_order(self):
+        body = "#### TL;DR\nSummary.\n"
+        subs = api.SubsectionReviewer.ordered_subsections("story", body)
+        keys = [s.key for s in subs]
+        assert "user_story" in keys
+        assert "acceptance_criteria" in keys
+        # user_story before tldr in template order
+        assert keys.index("user_story") < keys.index("tldr")
+
+    def test_empty_body_returns_stubs_with_blank_content(self):
+        subs = api.SubsectionReviewer.ordered_subsections("scope", "")
+        for s in subs:
+            assert s.original_content == ""
+            assert s.verdict == "pending"
+
+
+# ---------------------------------------------------------------------------
+# SessionManager — start, load, verdict, pause/resume, atomic persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManager:
+    def _walker_stub(self, *args, **kwargs):
+        return [
+            {
+                "number": 100,
+                "title": "Project Scope: Test",
+                "level": "scope",
+                "parent_number": None,
+            },
+            {
+                "number": 101,
+                "title": "Story: Test Story",
+                "level": "story",
+                "parent_number": 100,
+            },
+        ]
+
+    def test_start_creates_session_on_disk(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with patch.object(
+            api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+        ):
+            session = mgr.start(100, "owner/repo")
+        session_path = tmp_path / f"{session.session_id}.json"
+        assert session_path.is_file()
+        assert len(session.issues) == 2
+
+    def test_load_round_trips_session_state(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with patch.object(
+            api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+        ):
+            original = mgr.start(100, "owner/repo")
+        loaded = mgr.load(original.session_id)
+        assert loaded.session_id == original.session_id
+        assert loaded.scope_issue_number == original.scope_issue_number
+        assert len(loaded.issues) == len(original.issues)
+
+    def test_load_missing_session_raises(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with pytest.raises(FileNotFoundError):
+            mgr.load("does-not-exist")
+
+    def test_skip_issues_filters_walker_output(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with patch.object(
+            api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+        ):
+            session = mgr.start(100, "owner/repo", skip_issues={101})
+        numbers = [i.number for i in session.issues]
+        assert 101 not in numbers
+        assert 100 in numbers
+
+    def test_apply_verdict_approved_advances_cursor(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with (
+            patch.object(
+                api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+            ),
+            patch.object(
+                api, "get_issue_body", return_value="#### Business Problem\nx\n"
+            ),
+        ):
+            session = mgr.start(100, "owner/repo")
+            mgr.apply_verdict(session, "approved")
+        assert session.current_subsection_index == 1
+
+    def test_apply_verdict_improved_stores_content(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with (
+            patch.object(
+                api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+            ),
+            patch.object(
+                api, "get_issue_body", return_value="#### Business Problem\nx\n"
+            ),
+        ):
+            session = mgr.start(100, "owner/repo")
+            mgr.apply_verdict(session, "improved", improved_content="NEW TEXT")
+        sub = session.issues[0].subsections[0]
+        assert sub.verdict == "improved"
+        assert sub.approved_content == "NEW TEXT"
+
+    def test_pause_then_resume_round_trips(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with patch.object(
+            api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+        ):
+            session = mgr.start(100, "owner/repo")
+        mgr.pause(session)
+        assert session.status == "paused"
+        mgr.resume_session(session)
+        assert session.status == "active"
+
+    def test_session_completes_when_all_subsections_verdicted(self, tmp_path):
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with (
+            patch.object(
+                api,
+                "_walk_existing_hierarchy",
+                return_value=[
+                    {
+                        "number": 100,
+                        "title": "Scope",
+                        "level": "scope",
+                        "parent_number": None,
+                    }
+                ],
+            ),
+            patch.object(
+                api,
+                "get_issue_body",
+                return_value="Just leading text.\n",
+            ),
+        ):
+            session = mgr.start(100, "owner/repo")
+            # Approve every subsection
+            for _ in range(100):
+                pair = mgr.get_current_subsection(session)
+                if pair is None:
+                    break
+                mgr.apply_verdict(session, "approved")
+        assert session.status == "completed"
+
+    def test_atomic_write_survives_corruption_scenario(self, tmp_path):
+        """If the write is interrupted, the .tmp file shouldn't clobber the real
+        session file on load.  We simulate by checking that the file exists +
+        parses after each verdict."""
+        mgr = api.SessionManager(sessions_dir=tmp_path)
+        with (
+            patch.object(
+                api, "_walk_existing_hierarchy", side_effect=self._walker_stub
+            ),
+            patch.object(
+                api, "get_issue_body", return_value="#### Business Problem\nx\n"
+            ),
+        ):
+            session = mgr.start(100, "owner/repo")
+            mgr.apply_verdict(session, "approved")
+        # Reload succeeds + matches
+        loaded = mgr.load(session.session_id)
+        assert loaded.current_subsection_index == 1
+
+
+# ---------------------------------------------------------------------------
+# LLMPromptBuilder — prompt scaffolding
+# ---------------------------------------------------------------------------
+
+
+class TestLLMPromptBuilder:
+    def test_summary_prompt_mentions_subsection_key_and_level(self):
+        prompt = api.LLMPromptBuilder.build_summary_prompt(
+            "story", "why_this_matters", "some content"
+        )
+        assert "why_this_matters" in prompt
+        assert "story" in prompt
+        assert "some content" in prompt
+        assert "voice" in prompt.lower() or "narration" in prompt.lower()
+
+    def test_improvement_prompt_includes_rag_when_provided(self):
+        prompt = api.LLMPromptBuilder.build_improvement_prompt(
+            "scope",
+            "business_problem",
+            "old content",
+            rag_context="prior approved content",
+        )
+        assert "prior approved content" in prompt
+        assert "Relevant prior approvals" in prompt
+
+    def test_improvement_prompt_without_rag_omits_block(self):
+        prompt = api.LLMPromptBuilder.build_improvement_prompt(
+            "scope", "business_problem", "old content"
+        )
+        assert "Relevant prior approvals" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# WriteBacker — mocked gh issue edit round trip
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBacker:
+    def test_write_back_issue_uses_approved_content(self, tmp_path):
+        from scripts.sbr.api import IssueReview, Session, SubsectionReview
+
+        session = Session(
+            session_id="s1",
+            scope_issue_number=100,
+            repo="owner/repo",
+            created_at="2026-04-22T00:00:00Z",
+        )
+        issue = IssueReview(
+            number=101,
+            title="Story: Test",
+            level="story",
+            subsections=[
+                SubsectionReview(
+                    key="user_story",
+                    verdict="improved",
+                    original_content="old As-a block",
+                    approved_content=(
+                        "As a developer,\nI want coverage,\nSo that tests catch drift."
+                    ),
+                ),
+                SubsectionReview(
+                    key="tldr",
+                    verdict="approved",
+                    original_content="Summary one-liner.",
+                    approved_content="Summary one-liner.",
+                ),
+            ],
+        )
+        session.issues = [issue]
+
+        with (
+            patch.object(
+                api, "get_issue_body", return_value="# User Story: Test\n\nOld body."
+            ),
+            patch.object(api, "update_issue_body") as upd,
+        ):
+            result = api.WriteBacker.write_back_issue(session, issue)
+
+        # update_issue_body called with repo + issue number + some new body
+        assert upd.called
+        args, _ = upd.call_args
+        assert args[0] == "owner/repo"
+        assert args[1] == 101
+        new_body = args[2]
+        # Improved content appears in the rendered body
+        assert "As a developer" in new_body
+        # WriteBacker returns diff summary
+        assert result["issue_number"] == 101
+        assert issue.write_back_completed is True

--- a/scripts/tests/test_sbr_cli.py
+++ b/scripts/tests/test_sbr_cli.py
@@ -1,0 +1,243 @@
+"""Tests for scripts/sbr/cli.py — CLI subcommand dispatch."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from scripts.sbr import api, cli
+
+
+class TestCliStickySession:
+    def test_start_writes_current_session_file(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SBR_SESSIONS_DIR", str(tmp_path / "sessions"))
+        monkeypatch.setenv("SBR_CURRENT_SESSION_FILE", str(tmp_path / "current.txt"))
+
+        with patch.object(
+            api,
+            "_walk_existing_hierarchy",
+            return_value=[
+                {
+                    "number": 100,
+                    "title": "Scope",
+                    "level": "scope",
+                    "parent_number": None,
+                }
+            ],
+        ):
+            rc = cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+
+        assert rc == 0
+        current = (tmp_path / "current.txt").read_text()
+        assert current, "sticky session file should be written"
+        # JSON output is valid
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["queue_size"] == 1
+
+    def test_next_uses_sticky_session(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SBR_SESSIONS_DIR", str(tmp_path / "sessions"))
+        monkeypatch.setenv("SBR_CURRENT_SESSION_FILE", str(tmp_path / "current.txt"))
+
+        with (
+            patch.object(
+                api,
+                "_walk_existing_hierarchy",
+                return_value=[
+                    {
+                        "number": 100,
+                        "title": "Scope",
+                        "level": "scope",
+                        "parent_number": None,
+                    }
+                ],
+            ),
+            patch.object(api, "get_issue_body", return_value="Vision text.\n"),
+        ):
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            capsys.readouterr()  # flush start output
+            rc = cli.main(["--format", "json", "next"])
+
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["has_next"] is True
+        assert payload["issue_number"] == 100
+        assert payload["subsection_key"] == "vision"
+
+    def test_approve_advances_cursor(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SBR_SESSIONS_DIR", str(tmp_path / "sessions"))
+        monkeypatch.setenv("SBR_CURRENT_SESSION_FILE", str(tmp_path / "current.txt"))
+        with (
+            patch.object(
+                api,
+                "_walk_existing_hierarchy",
+                return_value=[
+                    {
+                        "number": 100,
+                        "title": "Scope",
+                        "level": "scope",
+                        "parent_number": None,
+                    }
+                ],
+            ),
+            patch.object(api, "get_issue_body", return_value="Vision text.\n"),
+        ):
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            cli.main(["--format", "json", "next"])
+            capsys.readouterr()
+            rc = cli.main(["--format", "json", "approve"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "approved"
+
+    def test_improve_reads_from_stdin_on_dash(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SBR_SESSIONS_DIR", str(tmp_path / "sessions"))
+        monkeypatch.setenv("SBR_CURRENT_SESSION_FILE", str(tmp_path / "current.txt"))
+        import io
+
+        with (
+            patch.object(
+                api,
+                "_walk_existing_hierarchy",
+                return_value=[
+                    {
+                        "number": 100,
+                        "title": "Scope",
+                        "level": "scope",
+                        "parent_number": None,
+                    }
+                ],
+            ),
+            patch.object(api, "get_issue_body", return_value="Vision text.\n"),
+        ):
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            cli.main(["--format", "json", "next"])
+            capsys.readouterr()
+            monkeypatch.setattr("sys.stdin", io.StringIO("improved vision text"))
+            rc = cli.main(["--format", "json", "improve", "-"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "improved"
+
+
+class TestCliLifecycle:
+    """Coverage for pause / resume / terminate / status / verbatim / write-back."""
+
+    def _setup_session(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SBR_SESSIONS_DIR", str(tmp_path / "sessions"))
+        monkeypatch.setenv("SBR_CURRENT_SESSION_FILE", str(tmp_path / "current.txt"))
+        walker = patch.object(
+            api,
+            "_walk_existing_hierarchy",
+            return_value=[
+                {
+                    "number": 100,
+                    "title": "Scope",
+                    "level": "scope",
+                    "parent_number": None,
+                }
+            ],
+        )
+        body = patch.object(api, "get_issue_body", return_value="Vision text.\n")
+        return walker, body
+
+    def test_status_of_fresh_session(self, tmp_path, monkeypatch, capsys):
+        walker, body = self._setup_session(tmp_path, monkeypatch)
+        with walker, body:
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            capsys.readouterr()
+            rc = cli.main(["--format", "json", "status"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["total_issues"] == 1
+        assert payload["approved"] == 0
+
+    def test_pause_then_resume(self, tmp_path, monkeypatch, capsys):
+        walker, body = self._setup_session(tmp_path, monkeypatch)
+        with walker, body:
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            capsys.readouterr()
+            cli.main(["--format", "json", "pause"])
+            payload_paused = json.loads(capsys.readouterr().out)
+            assert payload_paused["status"] == "paused"
+            cli.main(["--format", "json", "resume"])
+            payload_resumed = json.loads(capsys.readouterr().out)
+            assert payload_resumed["status"] == "active"
+
+    def test_terminate(self, tmp_path, monkeypatch, capsys):
+        walker, body = self._setup_session(tmp_path, monkeypatch)
+        with walker, body:
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            capsys.readouterr()
+            rc = cli.main(["--format", "json", "terminate"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "terminated"
+
+    def test_verbatim_prints_raw_content(self, tmp_path, monkeypatch, capsys):
+        walker, body = self._setup_session(tmp_path, monkeypatch)
+        with walker, body:
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            cli.main(["--format", "json", "next"])
+            capsys.readouterr()
+            rc = cli.main(["verbatim"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Vision section is empty in the mock body → "(empty)"
+        assert out.strip() == "(empty)"
+
+    def test_skip_advances(self, tmp_path, monkeypatch, capsys):
+        walker, body = self._setup_session(tmp_path, monkeypatch)
+        with walker, body:
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            cli.main(["--format", "json", "next"])
+            capsys.readouterr()
+            rc = cli.main(["--format", "json", "skip"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "skipped"
+
+    def test_write_back_with_no_verdicts_writes_nothing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        walker, body = self._setup_session(tmp_path, monkeypatch)
+        with walker, body, patch.object(api, "update_issue_body"):
+            cli.main(
+                ["--format", "json", "start", "--scope", "100", "--repo", "owner/repo"]
+            )
+            capsys.readouterr()
+            rc = cli.main(["--format", "json", "write-back"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["write_back_count"] == 0
+
+
+class TestCliStatus:
+    def test_status_with_no_session_exits(self, tmp_path, monkeypatch, capsys):
+        import pytest
+
+        monkeypatch.setenv("SBR_SESSIONS_DIR", str(tmp_path / "sessions"))
+        monkeypatch.setenv("SBR_CURRENT_SESSION_FILE", str(tmp_path / "current.txt"))
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(["status"])
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "No session" in err

--- a/scripts/tests/test_sbr_mcp_server.py
+++ b/scripts/tests/test_sbr_mcp_server.py
@@ -1,0 +1,59 @@
+"""Tests for scripts/sbr/mcp_server.py — MCP tool registration + dispatch."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from scripts.sbr import mcp_server
+
+
+class TestMainGracefulFallback:
+    def test_main_without_mcp_sdk_prints_remediation(self, capsys, monkeypatch):
+        """When `mcp` SDK isn't installed, main() returns non-zero + prints hint."""
+        monkeypatch.setattr(mcp_server, "FastMCP", None)
+        rc = mcp_server.main()
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "mcp" in err.lower() and "install" in err.lower()
+
+
+@pytest.mark.skipif(
+    mcp_server.FastMCP is None, reason="mcp SDK not installed in this env"
+)
+class TestBuildServerRegistersTools:
+    def test_build_server_registers_expected_tools(self):
+        """FastMCP server exposes the 10 canonical SBR tools after build."""
+        server = mcp_server._build_server()
+        # FastMCP stores tools internally; introspect via the registered names.
+        # The exact attribute can vary by SDK version; try a few known paths.
+        tool_names: set[str] = set()
+        # FastMCP uses _tool_manager.list_tools() in newer versions
+        try:
+            import asyncio
+            tools = asyncio.run(server._tool_manager.list_tools())
+            tool_names = {t.name for t in tools}
+        except (AttributeError, Exception):
+            # Fallback — inspect the tools list directly
+            tm = getattr(server, "_tool_manager", None)
+            if tm is not None:
+                tool_names = set(getattr(tm, "_tools", {}).keys())
+        expected = {
+            "sbr_start_session",
+            "sbr_next_subsection",
+            "sbr_current_subsection_verbatim",
+            "sbr_approve",
+            "sbr_improve",
+            "sbr_skip",
+            "sbr_pause",
+            "sbr_resume",
+            "sbr_terminate",
+            "sbr_session_status",
+            "sbr_write_back",
+        }
+        # At least the 10 canonical tools should be registered
+        assert expected.issubset(tool_names), (
+            f"missing tools: {expected - tool_names}"
+        )


### PR DESCRIPTION
Delivers Stage 1 MVP of Sprint Backlog Review (8 stories in one PR). `sbr` + `sbr-mcp-server` console scripts; 11 canonical operations mirrored across both surfaces; atomic JSON session persistence; reuses skill's walker + subsection parser + preserve-zone + template renderer. 34 new tests; 419/419 passing, 83.90% coverage.

See commit body for full Story coverage table.