### PR TITLE
fix(create_issues): require safety phrase 'AGREE TO SHALLOW SUBSECTIONS' to bypass subsection-schema gate

### DIFF
--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -2185,6 +2185,103 @@ def _iter_hierarchy_items(
     return out
 
 
+_ALLOW_SHALLOW_SAFETY_PHRASE = "AGREE TO SHALLOW SUBSECTIONS"
+_ALLOW_SHALLOW_SAFETY_ENV_VAR = "SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM"
+
+
+def _confirm_allow_shallow_subsections_safety_phrase() -> None:
+    """
+    Safety-phrase gate for --allow-shallow-subsections (added 2026-04-27).
+
+    Forces the operator to make a conscious, deliberate decision to bypass the
+    FR #45 subsection-schema gate. Two acceptance paths:
+
+      1. Interactive (TTY): prompts the operator to type the exact phrase
+         `AGREE TO SHALLOW SUBSECTIONS`. Anything else aborts with exit 3.
+
+      2. Non-interactive (CI / scripts): must set the env var
+         `SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM` to the same
+         exact phrase. Anything else aborts with exit 3.
+
+    Both paths fail-closed. By design this is awkward to automate — the
+    point is to keep `--allow-shallow-subsections` from being silently
+    used as a routine flag, which is what produced 30+ empty-template
+    story bodies under PS-182 in 2026-04 and derailed weeks of dispatch
+    work.
+
+    Returns None on confirmed acceptance. Calls sys.exit(3) on any
+    mismatch / missing path / non-interactive without env var.
+    """
+    expected = _ALLOW_SHALLOW_SAFETY_PHRASE
+    env_var_name = _ALLOW_SHALLOW_SAFETY_ENV_VAR
+
+    env_value = os.environ.get(env_var_name, "")
+    if env_value:
+        if env_value == expected:
+            print(
+                f"[subsection-schema] safety phrase confirmed via env var "
+                f"{env_var_name}.",
+                file=sys.stderr,
+            )
+            return
+        print(
+            f"\n[subsection-schema] FAIL: env var {env_var_name} is set but does\n"
+            f"  not match the required safety phrase. Set it to (exact match,\n"
+            f"  including capitalisation and spaces):\n"
+            f"    '{expected}'",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    if not sys.stdin.isatty():
+        print(
+            f"\n[subsection-schema] FAIL: --allow-shallow-subsections requires explicit\n"
+            f"  operator confirmation. This run has no TTY (e.g. CI / piped stdin),\n"
+            f"  so the interactive prompt cannot be shown.\n"
+            f"  Either:\n"
+            f"    (a) Run interactively in a terminal so you can type the safety phrase, OR\n"
+            f"    (b) Set env var {env_var_name} to the exact phrase:\n"
+            f"          {env_var_name}='{expected}'\n"
+            f"  This guard exists because shallow-bypass produced 30+ empty-template\n"
+            f"  issue bodies under PS-182 in 2026-04. Don't disable it without the\n"
+            f"  safety phrase.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    print(
+        f"\n[subsection-schema] --allow-shallow-subsections requires confirmation.\n"
+        f"  This bypass produced 30+ empty-template issue bodies under PS-182 in\n"
+        f"  2026-04 and derailed weeks of orchestrated dispatch.\n"
+        f"\n"
+        f"  Type the EXACT phrase below to proceed (case + spaces matter):\n"
+        f"    {expected}\n",
+        file=sys.stderr,
+    )
+    try:
+        response = input("> ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print(
+            "\n[subsection-schema] FAIL: confirmation cancelled. Aborting.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    if response == expected:
+        print(
+            "[subsection-schema] safety phrase confirmed — proceeding with shallow "
+            "subsections.",
+            file=sys.stderr,
+        )
+        return
+    print(
+        f"\n[subsection-schema] FAIL: safety phrase did not match. Aborting.\n"
+        f"  Expected: '{expected}'\n"
+        f"  Got:      '{response}'",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+
 def enforce_subsection_schema(
     hierarchy: dict[str, Any],
     allow_shallow: bool = False,
@@ -2220,6 +2317,17 @@ def enforce_subsection_schema(
         print(f"    missing: {', '.join(missing)}", file=sys.stderr)
 
     if allow_shallow:
+        # Safety-phrase confirmation gate (added 2026-04-27 per operator
+        # directive after PS-182 incident: a routine `--allow-shallow-subsections`
+        # run silently produced 30+ empty-template story bodies that workers
+        # could not act on, derailing weeks of orchestrated dispatch).
+        #
+        # Force the operator to type the EXACT phrase below before the bypass
+        # is accepted. Non-interactive runs (CI / scripts) must set the env
+        # var SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM to the same
+        # exact phrase. Both paths require a deliberate, conscious decision —
+        # by design, this is awkward to automate.
+        _confirm_allow_shallow_subsections_safety_phrase()
         print(
             "\n[subsection-schema] --allow-shallow-subsections set; proceeding.\n"
             "  Generated issue bodies will carry template placeholder leaks\n"
@@ -2232,7 +2340,9 @@ def enforce_subsection_schema(
     print(
         "\n[subsection-schema] FAIL: plans MUST use the full subsection schema.\n"
         "  See references/plan-format.md for per-level required subsections.\n"
-        "  Emergency bypass: pass --allow-shallow-subsections (document why).",
+        "  Emergency bypass: pass --allow-shallow-subsections AND confirm the\n"
+        "  safety phrase 'AGREE TO SHALLOW SUBSECTIONS' (interactive prompt or\n"
+        "  env var SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM). Document why.",
         file=sys.stderr,
     )
     sys.exit(3)
@@ -3147,7 +3257,11 @@ def main() -> None:
         help=(
             "FR #45: bypass the required-subsection gate (default: fail-fast "
             "when plan items lack per-level required subsections). "
-            "Use SPARINGLY — document why in commit / PR body."
+            "REQUIRES safety-phrase confirmation: the operator must type "
+            "'AGREE TO SHALLOW SUBSECTIONS' interactively, OR set env var "
+            "SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM to the same "
+            "exact phrase for non-interactive runs. Use SPARINGLY — document "
+            "why in commit / PR body."
         ),
     )
     p_create.add_argument(
@@ -3210,7 +3324,11 @@ def main() -> None:
         help=(
             "FR #45: bypass the required-subsection gate. Default: fail-fast "
             "when plan items lack per-level required subsections. "
-            "Document why you used this flag in the commit / PR body."
+            "REQUIRES safety-phrase confirmation: the operator must type "
+            "'AGREE TO SHALLOW SUBSECTIONS' interactively, OR set env var "
+            "SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM to the same "
+            "exact phrase for non-interactive runs. Document why you used "
+            "this flag in the commit / PR body."
         ),
     )
 
@@ -3268,7 +3386,11 @@ def main() -> None:
         help=(
             "FR #45: bypass the required-subsection gate. Default: fail-fast "
             "when plan items lack per-level required subsections. "
-            "Document why you used this flag in the commit / PR body."
+            "REQUIRES safety-phrase confirmation: the operator must type "
+            "'AGREE TO SHALLOW SUBSECTIONS' interactively, OR set env var "
+            "SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM to the same "
+            "exact phrase for non-interactive runs. Document why you used "
+            "this flag in the commit / PR body."
         ),
     )
     p_amend.add_argument(

--- a/scripts/create_issues.py
+++ b/scripts/create_issues.py
@@ -2235,15 +2235,20 @@ def _confirm_allow_shallow_subsections_safety_phrase() -> None:
 
     if not sys.stdin.isatty():
         print(
-            f"\n[subsection-schema] FAIL: --allow-shallow-subsections requires explicit\n"
-            f"  operator confirmation. This run has no TTY (e.g. CI / piped stdin),\n"
+            f"\n[subsection-schema] FAIL: --allow-shallow-subsections requires "
+            f"explicit\n"
+            f"  operator confirmation. This run has no TTY (e.g. CI / piped "
+            f"stdin),\n"
             f"  so the interactive prompt cannot be shown.\n"
             f"  Either:\n"
-            f"    (a) Run interactively in a terminal so you can type the safety phrase, OR\n"
+            f"    (a) Run interactively in a terminal so you can type the "
+            f"safety phrase, OR\n"
             f"    (b) Set env var {env_var_name} to the exact phrase:\n"
             f"          {env_var_name}='{expected}'\n"
-            f"  This guard exists because shallow-bypass produced 30+ empty-template\n"
-            f"  issue bodies under PS-182 in 2026-04. Don't disable it without the\n"
+            f"  This guard exists because shallow-bypass produced 30+ "
+            f"empty-template\n"
+            f"  issue bodies under PS-182 in 2026-04. Don't disable it without "
+            f"the\n"
             f"  safety phrase.",
             file=sys.stderr,
         )
@@ -2259,7 +2264,11 @@ def _confirm_allow_shallow_subsections_safety_phrase() -> None:
         file=sys.stderr,
     )
     try:
-        response = input("> ").strip()
+        # NOTE: do NOT call .strip() here — exact match means exact match.
+        # If the operator types trailing whitespace, that's a near-miss and
+        # we want to make them retype it cleanly. Same rule applies to the
+        # env-var check above (no .strip() there either).
+        response = input("> ")
     except (EOFError, KeyboardInterrupt):
         print(
             "\n[subsection-schema] FAIL: confirmation cancelled. Aborting.",

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import json
-import os
 import textwrap
 from unittest.mock import MagicMock
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Safety-phrase env var: tests that exercise --allow-shallow-subsections

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -3,8 +3,36 @@
 from __future__ import annotations
 
 import json
+import os
 import textwrap
 from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Safety-phrase env var: tests that exercise --allow-shallow-subsections
+# need to satisfy the 2026-04-27 safety gate. Set the env var globally for
+# the test session (autouse) so existing tests that pass
+# `allow_shallow=True` keep working without each test setting it.
+#
+# Tests that EXPLICITLY want to verify the safety-gate behaviour (missing
+# / wrong phrase) MUST monkeypatch.delenv() or monkeypatch.setenv() with a
+# non-matching value to override this fixture.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _allow_shallow_subsections_safety_phrase(monkeypatch):
+    """Auto-confirm the --allow-shallow-subsections safety phrase for all
+    tests so the test suite isn't forced through the interactive prompt.
+    Tests that need to verify the gate's failure paths can override.
+    """
+    monkeypatch.setenv(
+        "SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM",
+        "AGREE TO SHALLOW SUBSECTIONS",
+    )
+    yield
 
 # ---------------------------------------------------------------------------
 # Mock helpers

--- a/scripts/tests/test_ep002_ep003_scripts.py
+++ b/scripts/tests/test_ep002_ep003_scripts.py
@@ -1150,9 +1150,19 @@ class TestFR45RequiredSubsectionGate:
             create_issues.enforce_subsection_schema(hierarchy)
         assert exc_info.value.code == 3
 
-    def test_enforce_subsection_schema_proceeds_with_allow_shallow(self, capsys):
+    def test_enforce_subsection_schema_proceeds_with_allow_shallow_via_env_phrase(
+        self, capsys, monkeypatch
+    ):
+        """Updated 2026-04-27: --allow-shallow-subsections now requires the
+        safety phrase. In non-interactive runs (pytest), the env-var path is
+        the supported way to opt in.
+        """
         from scripts import create_issues
 
+        monkeypatch.setenv(
+            create_issues._ALLOW_SHALLOW_SAFETY_ENV_VAR,
+            create_issues._ALLOW_SHALLOW_SAFETY_PHRASE,
+        )
         hierarchy = {
             "scope": {"title": "Scope", "subsections": {}},
             "initiatives": [],
@@ -1161,12 +1171,72 @@ class TestFR45RequiredSubsectionGate:
             "tasks": [],
         }
         gaps = create_issues.enforce_subsection_schema(hierarchy, allow_shallow=True)
-        # gaps returned even when allow_shallow; operator sees warning but
-        # execution continues
+        # gaps returned even when allow_shallow + safety phrase confirmed;
+        # operator sees warning but execution continues
         assert len(gaps) == 1
         assert gaps[0][0] == "scope"
         captured = capsys.readouterr()
+        assert "safety phrase confirmed via env var" in captured.err
         assert "allow-shallow-subsections set" in captured.err
+
+    def test_enforce_subsection_schema_aborts_when_safety_phrase_missing(
+        self, capsys, monkeypatch
+    ):
+        """Without the env var AND without a TTY, --allow-shallow-subsections
+        must exit non-zero before any issue body is generated.
+
+        This is the 2026-04-27 PS-182 hardening: a routine
+        `--allow-shallow-subsections` run silently produced 30+ empty-template
+        story bodies. The new safety gate forces an explicit, conscious opt-in.
+        """
+        from scripts import create_issues
+
+        # No env var + pytest's stdin is not a TTY.
+        monkeypatch.delenv(
+            create_issues._ALLOW_SHALLOW_SAFETY_ENV_VAR, raising=False
+        )
+        hierarchy = {
+            "scope": {"title": "Scope", "subsections": {}},
+            "initiatives": [],
+            "epics": [],
+            "stories": [],
+            "tasks": [],
+        }
+        with pytest.raises(SystemExit) as exc_info:
+            create_issues.enforce_subsection_schema(hierarchy, allow_shallow=True)
+        assert exc_info.value.code == 3
+        captured = capsys.readouterr()
+        assert "requires explicit" in captured.err
+        assert "AGREE TO SHALLOW SUBSECTIONS" in captured.err
+
+    def test_enforce_subsection_schema_aborts_when_safety_phrase_wrong(
+        self, capsys, monkeypatch
+    ):
+        """Setting the env var to a non-matching value must abort. The phrase
+        is exact-match (case + spaces matter); typos and approximations all
+        fail-closed.
+        """
+        from scripts import create_issues
+
+        monkeypatch.setenv(
+            create_issues._ALLOW_SHALLOW_SAFETY_ENV_VAR,
+            "agree to shallow subsections",  # wrong case
+        )
+        hierarchy = {
+            "scope": {"title": "Scope", "subsections": {}},
+            "initiatives": [],
+            "epics": [],
+            "stories": [],
+            "tasks": [],
+        }
+        with pytest.raises(SystemExit) as exc_info:
+            create_issues.enforce_subsection_schema(hierarchy, allow_shallow=True)
+        assert exc_info.value.code == 3
+        captured = capsys.readouterr()
+        # The wrapped message reads "...is set but does\n  not match the required safety phrase.\n"
+        # so the substring "match the required safety phrase" is contiguous on one line.
+        assert "match the required safety phrase" in captured.err
+        assert "AGREE TO SHALLOW SUBSECTIONS" in captured.err
 
 
 class TestRefreshMode:


### PR DESCRIPTION
## Summary

\`--allow-shallow-subsections\` is now **safety-phrase-gated** per operator directive 2026-04-27.

## Why

The PS-182 incident: a routine \`--allow-shallow-subsections\` run silently produced **30+ empty-template story bodies** under EP-184 → EP-189 in \`kdtix-open/agent-project-queue\`. Workers couldn't act on \`[ROLE]\` / \`[WHAT]\` / \`[ACCEPTANCE CRITERION 1]\` placeholders, fail-fast CI gates triggered repeatedly, and the orchestrator loop wasted weeks of dispatch cycles on inputs that could never produce meaningful output.

> **Operator directive (verbatim)**: *"This \`--allow-shallow-subsections\` is getting us into trouble and needs to be blocked. 'AGREE TO SHALLOW SUBSECTIONS' forcing the user to type in this exact phrase (like a safety word the operator has to type in manually) to keep future plans from being converted with this. I'm not sure we should keep it."*

This PR keeps the flag (some legitimate emergency uses remain) but makes its acceptance **deliberately awkward** so it cannot be set casually.

## Behavior

When \`--allow-shallow-subsections\` is passed AND the plan has missing required subsections:

| Path | Acceptance |
|---|---|
| **Interactive (TTY)** | Prompt the operator; user must type \`AGREE TO SHALLOW SUBSECTIONS\` exactly. Anything else → exit 3. |
| **Non-interactive (CI / scripts)** | Must set env var \`SKILL_PLAN_TO_PROJECT_SHALLOW_SUBSECTIONS_CONFIRM\` to the same exact phrase. Anything else → exit 3. |
| **Without flag** | Unchanged — fail-fast on schema gaps as before. |

Both paths fail-closed. The phrase is exact-match (case + spaces).

## Implementation

- New helper \`_confirm_allow_shallow_subsections_safety_phrase()\` in \`scripts/create_issues.py\`. Called once from \`enforce_subsection_schema\` immediately before the existing "proceeding" branch.
- Help text on all 3 argparse instances (\`create\` / \`refresh\` / \`amend\`) updated to surface the safety-phrase requirement.
- FAIL message updated to point at both the flag AND the phrase.

## Tests

- \`test_enforce_subsection_schema_aborts_when_safety_phrase_missing\` — no env var + no TTY → exits 3 with explanatory message.
- \`test_enforce_subsection_schema_aborts_when_safety_phrase_wrong\` — env var present but case-mismatched → exits 3.
- Renamed existing \`test_enforce_subsection_schema_proceeds_with_allow_shallow\` to \`..._proceeds_with_allow_shallow_via_env_phrase\` to reflect the supported non-interactive path.
- Added autouse fixture in \`scripts/tests/conftest.py\` that pre-confirms the safety phrase env var for all tests, so existing tests that pass \`allow_shallow_subsections=True\` keep working without per-test setup.
- **170/170 tests pass locally.**

## Out of scope (follow-ups, not in this PR)

- Updating the SKILL.md / references/plan-format.md operator-facing docs to describe the safety phrase. (Recommended P1 follow-up.)
- Wiring a CHANGELOG.md entry. (Repo's CHANGELOG.md exists at root; add as next commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>